### PR TITLE
Issue 4 restrict access to certain announcements

### DIFF
--- a/appinfo/database.xml
+++ b/appinfo/database.xml
@@ -4,6 +4,7 @@
 	<create>true</create>
 	<overwrite>false</overwrite>
 	<charset>utf8</charset>
+
 	<table>
 		<name>*dbprefix*announcements</name>
 		<declaration>
@@ -39,6 +40,35 @@
 				<type>clob</type>
 				<notnull>false</notnull>
 			</field>
+		</declaration>
+	</table>
+
+	<table>
+		<name>*dbprefix*announcements_groups</name>
+		<declaration>
+			<field>
+				<name>announcement_id</name>
+				<type>integer</type>
+				<notnull>true</notnull>
+				<length>4</length>
+			</field>
+			<field>
+				<name>gid</name>
+				<type>text</type>
+				<notnull>true</notnull>
+				<length>64</length>
+			</field>
+
+			<index>
+				<name>announce_group</name>
+				<unique>true</unique>
+				<field>
+					<name>announcement_id</name>
+				</field>
+				<field>
+					<name>gid</name>
+				</field>
+			</index>
 		</declaration>
 	</table>
 </database>

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -5,7 +5,7 @@
 	<description>An announcement center for Nextcloud</description>
 	<licence>AGPL</licence>
 	<author>Joas Schilling</author>
-	<version>1.2.0</version>
+	<version>1.3.0</version>
 	<namespace>AnnouncementCenter</namespace>
 
 	<category>other</category>

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -9,6 +9,8 @@
 	<namespace>AnnouncementCenter</namespace>
 
 	<category>other</category>
+	<ocsid>173921</ocsid>
+
 	<website>https://github.com/nextcloud/announcementcenter</website>
 	<bugs>https://github.com/nextcloud/announcementcenter/issues</bugs>
 	<repository type="git">https://github.com/nextcloud/announcementcenter.git</repository>
@@ -16,5 +18,10 @@
 	<dependencies>
 		<owncloud min-version="9.1" max-version="9.1" />
 	</dependencies>
-	<ocsid>173921</ocsid>
+
+	<repair-steps>
+		<post-migration>
+			<step>OCA\AnnouncementCenter\Migration\AnnouncementsGroupsLinks</step>
+		</post-migration>
+	</repair-steps>
 </info>

--- a/css/style.css
+++ b/css/style.css
@@ -34,6 +34,7 @@
 .announcementcenter .visibility img {
 	width: 16px;
 	vertical-align: middle;
+	padding-bottom: 3px;
 }
 
 .announcementcenter .delete-link {

--- a/css/style.css
+++ b/css/style.css
@@ -31,6 +31,11 @@
 	margin-top: 50px !important;
 }
 
+.announcementcenter .visibility img {
+	width: 16px;
+	vertical-align: middle;
+}
+
 .announcementcenter .delete-link {
 	display: none;
 }

--- a/js/script.js
+++ b/js/script.js
@@ -109,15 +109,7 @@
 			}).done(function(announcement) {
 				OC.msg.finishedSuccess('#announcement_submit_msg', t('announcementcenter', 'Announced!'));
 
-				var $html = $(self.compiledTemplate({
-					time: OC.Util.formatDate(announcement.time * 1000),
-					author: announcement.author,
-					subject: announcement.subject,
-					message: announcement.message,
-					announcementId: (oc_isadmin) ? announcement.id : 0
-				}));
-
-				$html.find('span.delete-link a').on('click', self.deleteAnnouncement);
+				var $html = self.announcementToHtml(announcement);
 				$('#app-content-wrapper .section:eq(0)').after($html);
 				$html.hide();
 				setTimeout(function() {
@@ -145,35 +137,8 @@
 			}).done(function (response) {
 				if (response.length > 0) {
 					_.each(response, function (announcement) {
-						var object = {
-							time: OC.Util.formatDate(announcement.time * 1000),
-							author: announcement.author,
-							subject: announcement.subject,
-							message: announcement.message,
-							visibilityEveryone: null,
-							visibilityString: null,
-							announcementId: (oc_isadmin) ? announcement.id : 0
-						};
-
-						if (oc_isadmin) {
-							if (announcement.groups.indexOf('everyone') > -1) {
-								object.visibilityEveryone = true;
-								object.visibilityString = t('announcementcenter', 'Visible for everyone');
-							} else {
-								object.visibilityEveryone = false;
-								object.visibilityString = t('announcementcenter', 'Visible for groups: {groups}', {
-									groups: announcement.groups.join(t('announcementcenter', ', '))
-								});
-							}
-						}
-
-						var $html = $(self.compiledTemplate(object));
-						$html.find('span.delete-link a').on('click', self.deleteAnnouncement);
-						$html.find('.has-tooltip').tooltip({
-							placement: 'bottom'
-						});
+						var $html = self.announcementToHtml(announcement);
 						$('#app-content-wrapper').append($html);
-
 						if (announcement.id < self.lastLoadedAnnouncement || self.lastLoadedAnnouncement === 0) {
 							self.lastLoadedAnnouncement = announcement.id;
 						}
@@ -183,6 +148,38 @@
 					$('#emptycontent').removeClass('hidden');
 				}
 			});
+		},
+
+		announcementToHtml: function (announcement) {
+			var object = {
+				time: OC.Util.formatDate(announcement.time * 1000),
+				author: announcement.author,
+				subject: announcement.subject,
+				message: announcement.message,
+				visibilityEveryone: null,
+				visibilityString: null,
+				announcementId: (oc_isadmin) ? announcement.id : 0
+			};
+
+			if (oc_isadmin) {
+				if (announcement.groups.indexOf('everyone') > -1) {
+					object.visibilityEveryone = true;
+					object.visibilityString = t('announcementcenter', 'Visible for everyone');
+				} else {
+					object.visibilityEveryone = false;
+					object.visibilityString = t('announcementcenter', 'Visible for groups: {groups}', {
+						groups: announcement.groups.join(t('announcementcenter', ', '))
+					});
+				}
+			}
+
+			var $html = $(this.compiledTemplate(object));
+			$html.find('span.delete-link a').on('click', this.deleteAnnouncement);
+			$html.find('.has-tooltip').tooltip({
+				placement: 'bottom'
+			});
+
+			return $html;
 		},
 
 		onScroll: function () {

--- a/js/script.js
+++ b/js/script.js
@@ -52,6 +52,15 @@
 
 			this.ignoreScroll = 1;
 			this.loadAnnouncements();
+
+			$('#groups').each(function (index, element) {
+				OC.Settings.setupGroupsSelect($(element));
+				$(element).change(function(ev) {
+					var groups = ev.val || [];
+					groups = JSON.stringify(groups);
+					OC.AppConfig.setValue('core', $(this).attr('name'), groups);
+				});
+			});
 		},
 
 		deleteAnnouncement: function() {
@@ -86,7 +95,8 @@
 				url: OC.generateUrl('/apps/announcementcenter/announcement'),
 				data: {
 					subject: $('#subject').val(),
-					message: $('#message').val()
+					message: $('#message').val(),
+					groups: $('#groups').val().split('|')
 				}
 			}).done(function(announcement) {
 				OC.msg.finishedSuccess('#announcement_submit_msg', t('announcementcenter', 'Announced!'));
@@ -109,6 +119,7 @@
 
 				$('#subject').val('');
 				$('#message').val('');
+				$('#groups').val('');
 			}).fail(function (response) {
 				OC.msg.finishedError('#announcement_submit_msg', response.responseJSON.error);
 			});

--- a/js/script.js
+++ b/js/script.js
@@ -21,14 +21,14 @@
 		$container: null,
 		$content: null,
 		lastLoadedAnnouncement: 0,
+		sevenDaysMilliseconds: 7 * 24 * 3600 * 1000,
 
 		compiledTemplate: null,
 		handlebarTemplate: '<div class="section">' +
 				'<h2>{{{subject}}}</h2>' +
 				'<em>' +
-					'{{author}} — {{time}}' +
+					'{{time}} {{author}} ' +
 					'{{#if announcementId}}' +
-						' — ' +
 						'<span class="visibility has-tooltip" title="{{{visibilityString}}}">' +
 							'{{#if visibilityEveryone}}' +
 								'<img src="' + OC.imagePath('core', 'places/link') + '">' +
@@ -151,15 +151,26 @@
 		},
 
 		announcementToHtml: function (announcement) {
+
+			var currentTimestamp = new Date().getTime();
+			var details = '';
+			if (currentTimestamp >= announcement.time * 1000 + this.sevenDaysMilliseconds) {
+				// Old announcement show full date
+				details += OC.Util.formatDate(announcement.time * 1000)
+			} else {
+				details += OC.Util.relativeModifiedDate(announcement.time * 1000)
+			}
+
 			var object = {
-				time: OC.Util.formatDate(announcement.time * 1000),
-				author: announcement.author,
+				time: details,
+				author: t('announcementcenter', 'by {author}', announcement),
 				subject: announcement.subject,
 				message: announcement.message,
 				visibilityEveryone: null,
 				visibilityString: null,
 				announcementId: (oc_isadmin) ? announcement.id : 0
 			};
+
 
 			if (oc_isadmin) {
 				if (announcement.groups.indexOf('everyone') > -1) {

--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -46,7 +46,7 @@ class Application extends App {
 				$server->getJobList(),
 				$server->getNotificationManager(),
 				$server->getL10N('announcementcenter'),
-				new Manager($server->getDatabaseConnection()),
+				$c->query('OCA\AnnouncementCenter\Manager'),
 				$this->getCurrentUser($server->getUserSession())
 			);
 		});

--- a/lib/Controller/PageController.php
+++ b/lib/Controller/PageController.php
@@ -123,12 +123,13 @@ class PageController extends Controller {
 	/**
 	 * @param string $subject
 	 * @param string $message
+	 * @param string[] $groups
 	 * @return JSONResponse
 	 */
-	public function add($subject, $message) {
+	public function add($subject, $message, array $groups) {
 		$timeStamp = time();
 		try {
-			$announcement = $this->manager->announce($subject, $message, $this->userId, $timeStamp);
+			$announcement = $this->manager->announce($subject, $message, $this->userId, $timeStamp, $groups);
 		} catch (\InvalidArgumentException $e) {
 			return new JSONResponse(
 				['error' => (string)$this->l->t('The subject is too long or empty')],

--- a/lib/Controller/PageController.php
+++ b/lib/Controller/PageController.php
@@ -114,6 +114,7 @@ class PageController extends Controller {
 				'time'		=> $row['time'],
 				'subject'	=> $row['subject'],
 				'message'	=> $row['message'],
+				'groups'	=> $row['groups'],
 			];
 		}
 

--- a/lib/Manager.php
+++ b/lib/Manager.php
@@ -225,7 +225,7 @@ class Manager {
 		}
 
 		if (!in_array('admin', $groups)) {
-			$query->rightJoin('a', 'announcements_groups', 'ag', $query->expr()->eq(
+			$query->leftJoin('a', 'announcements_groups', 'ag', $query->expr()->eq(
 					'a.announcement_id', 'ag.announcement_id'
 				))
 				->andWhere($query->expr()->in('ag.gid', $query->createNamedParameter($groups, IQueryBuilder::PARAM_STR_ARRAY)));

--- a/lib/Manager.php
+++ b/lib/Manager.php
@@ -174,7 +174,7 @@ class Manager {
 				$entry = $result->fetch();
 				$result->closeCursor();
 
-				if ($entry === null) {
+				if (!$entry) {
 					throw new \InvalidArgumentException('Invalid ID');
 				}
 			}
@@ -213,6 +213,7 @@ class Manager {
 		$query->select('a.*')
 			->from('announcements', 'a')
 			->orderBy('a.announcement_time', 'DESC')
+			->groupBy('a.announcement_id')
 			->setMaxResults($limit);
 
 		$user = $this->userSession->getUser();
@@ -224,9 +225,9 @@ class Manager {
 		}
 
 		if (!in_array('admin', $groups)) {
-			$query->leftJoin('a', 'announcements_groups', 'ag', $query->expr()->eq(
-				'a.announcement_id', 'ag.announcement_id'
-			))
+			$query->rightJoin('a', 'announcements_groups', 'ag', $query->expr()->eq(
+					'a.announcement_id', 'ag.announcement_id'
+				))
 				->andWhere($query->expr()->in('ag.gid', $query->createNamedParameter($groups, IQueryBuilder::PARAM_STR_ARRAY)));
 		}
 

--- a/lib/Manager.php
+++ b/lib/Manager.php
@@ -254,6 +254,28 @@ class Manager {
 	}
 
 	/**
+	 * Return the groups (or string everyone) which have access to the announcement
+	 *
+	 * @param int $id
+	 * @return string[]
+	 */
+	public function getGroups($id) {
+		$query = $this->connection->getQueryBuilder();
+		$query->select('gid')
+			->from('announcements_groups')
+			->where($query->expr()->eq('announcement_id', $query->createNamedParameter($id)));
+		$result = $query->execute();
+
+		$groups = [];
+		while ($row = $result->fetch()) {
+			$groups[] = $row['gid'];
+		}
+		$result->closeCursor();
+
+		return $groups;
+	}
+
+	/**
 	 * @param string $message
 	 * @return string
 	 */

--- a/lib/Migration/AnnouncementsGroupsLinks.php
+++ b/lib/Migration/AnnouncementsGroupsLinks.php
@@ -1,0 +1,88 @@
+<?php
+/**
+ * @copyright Copyright (c) 2016 Joas Schilling <coding@schilljs.com>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+
+namespace OCA\AnnouncementCenter\Migration;
+
+
+use OCP\DB\QueryBuilder\IQueryBuilder;
+use OCP\IDBConnection;
+use OCP\Migration\IOutput;
+use OCP\Migration\IRepairStep;
+
+class AnnouncementsGroupsLinks implements IRepairStep {
+
+	/** @var IDBConnection */
+	protected $connection;
+
+	/**
+	 * @param IDBConnection $connection
+	 */
+	public function __construct(IDBConnection $connection) {
+		$this->connection = $connection;
+	}
+
+	/**
+	 * Returns the step's name
+	 *
+	 * @return string
+	 * @since 9.1.0
+	 */
+	public function getName() {
+		return 'Add read permissions for existing announcements';
+	}
+
+	/**
+	 * Run repair step.
+	 * Must throw exception on error.
+	 *
+	 * @since 9.1.0
+	 * @param IOutput $output
+	 * @throws \Exception in case of failure
+	 */
+	public function run(IOutput $output) {
+		$queryInsert = $this->connection->getQueryBuilder();
+		$queryInsert->insert('announcements_groups')
+			->values([
+				'announcement_id' => $queryInsert->createParameter('aid'),
+				'gid' => $queryInsert->createNamedParameter('everyone'),
+			]);
+
+		$query = $this->connection->getQueryBuilder();
+		$query->select(['a.announcement_id', 'a.announcement_subject'])
+			->from('announcements', 'a')
+			->leftJoin('a', 'announcements_groups', 'ag', $query->expr()->eq(
+				'a.announcement_id', 'ag.announcement_id'
+			))
+			->where($query->expr()->isNull('ag.gid'));
+		$result = $query->execute();
+
+		$output->startProgress();
+		while ($row = $result->fetch()) {
+			$output->advance(1, $row['announcement_subject']);
+			$queryInsert->setParameter('aid', (int) $row['announcement_id'])
+				->execute();
+		}
+		$output->finishProgress();
+
+		$result->closeCursor();
+	}
+}

--- a/templates/part.add.php
+++ b/templates/part.add.php
@@ -2,6 +2,9 @@
 /**
  * @var \OCP\IL10N $l
  */
+vendor_script('select2/select2');
+vendor_style('select2/select2');
+script('settings', 'settings');
 ?>
 <form id="announce" class="section">
 	<h2><?php p($l->t('Add announcement')); ?></h2>
@@ -9,6 +12,10 @@
 	<input type="text" name="subject" id="subject" placeholder="<?php p($l->t('Subject…')); ?>" />
 	<br />
 	<textarea name="message" id="message" placeholder="<?php p($l->t('Your announcement…')); ?>"></textarea>
+	<br />
+	<input type="hidden" name="groups" id="groups" placeholder="<?php p($l->t('Groups…')); ?>" style="width: 400px;" />
+	<br />
+	<em><?php p($l->t('These groups will be able to see the announcement. If no group is selected, all users can see it.')); ?></em>
 	<br />
 	<input type="button" id="submit_announcement" value="<?php p($l->t('Announce')); ?>" name="submit" />
 	<span id="announcement_submit_msg" class="msg"></span>

--- a/tests/Controller/PageControllerTest.php
+++ b/tests/Controller/PageControllerTest.php
@@ -258,7 +258,7 @@ class PageControllerTest extends TestCase {
 		$controller->expects($this->never())
 			->method('createPublicity');
 
-		$response = $controller->add($subject, '');
+		$response = $controller->add($subject, '', []);
 
 		$this->assertInstanceOf('OCP\AppFramework\Http\JSONResponse', $response);
 		$this->assertSame($expectedData, $response->getData());
@@ -274,7 +274,7 @@ class PageControllerTest extends TestCase {
 	public function testAdd() {
 		$this->manager->expects($this->once())
 			->method('announce')
-			->with('subject', 'message', 'author', $this->anything())
+			->with('subject', 'message', 'author', $this->anything(), ['gid1'])
 			->willReturn([
 				'author' => 'author',
 				'subject' => 'subject',
@@ -292,7 +292,7 @@ class PageControllerTest extends TestCase {
 
 		$controller = $this->getController();
 
-		$response = $controller->add('subject', 'message');
+		$response = $controller->add('subject', 'message', ['gid1']);
 
 		$this->assertInstanceOf('OCP\AppFramework\Http\JSONResponse', $response);
 		$data = $response->getData();

--- a/tests/Controller/PageControllerTest.php
+++ b/tests/Controller/PageControllerTest.php
@@ -139,32 +139,32 @@ class PageControllerTest extends TestCase {
 			[
 				1,
 				[
-					['id' => 1337, 'author' => 'author1', 'subject' => 'Subject #1', 'message' => 'Message #1', 'time' => 1440672792],
+					['id' => 1337, 'author' => 'author1', 'subject' => 'Subject #1', 'message' => 'Message #1', 'time' => 1440672792, 'groups' => ['gid1']],
 				], [],
 				[
-					['id' => 1337, 'author' => 'author1', 'author_id' => 'author1', 'subject' => 'Subject #1', 'message' => 'Message #1', 'time' => 1440672792],
+					['id' => 1337, 'author' => 'author1', 'author_id' => 'author1', 'subject' => 'Subject #1', 'message' => 'Message #1', 'time' => 1440672792, 'groups' => ['gid1']],
 				],
 			],
 			[
 				1,
 				[
-					['id' => 23, 'author' => 'author1', 'subject' => 'Subject #1', 'message' => 'Message #1', 'time' => 1440672792],
+					['id' => 23, 'author' => 'author1', 'subject' => 'Subject #1', 'message' => 'Message #1', 'time' => 1440672792, 'groups' => ['gid1']],
 				],
 				[
 					['author1', $this->getUserMock('author1', 'Author One')],
 				],
 				[
-					['id' => 23, 'author' => 'Author One', 'author_id' => 'author1', 'subject' => 'Subject #1', 'message' => 'Message #1', 'time' => 1440672792],
+					['id' => 23, 'author' => 'Author One', 'author_id' => 'author1', 'subject' => 'Subject #1', 'message' => 'Message #1', 'time' => 1440672792, 'groups' => ['gid1']],
 				],
 			],
 			[
 				1,
 				[
-					['id' => 42, 'author' => 'author1', 'subject' => "Subject &lt;html&gt;#1&lt;/html&gt;", 'message' => "Message<br />&lt;html&gt;#1&lt;/html&gt;", 'time' => 1440672792],
+					['id' => 42, 'author' => 'author1', 'subject' => "Subject &lt;html&gt;#1&lt;/html&gt;", 'message' => "Message<br />&lt;html&gt;#1&lt;/html&gt;", 'time' => 1440672792, 'groups' => null],
 				],
 				[],
 				[
-					['id' => 42, 'author' => 'author1', 'author_id' => 'author1', 'subject' => 'Subject &lt;html&gt;#1&lt;/html&gt;', 'message' => 'Message<br />&lt;html&gt;#1&lt;/html&gt;', 'time' => 1440672792],
+					['id' => 42, 'author' => 'author1', 'author_id' => 'author1', 'subject' => 'Subject &lt;html&gt;#1&lt;/html&gt;', 'message' => 'Message<br />&lt;html&gt;#1&lt;/html&gt;', 'time' => 1440672792, 'groups' => null],
 				],
 			],
 		];

--- a/tests/ManagerTest.php
+++ b/tests/ManagerTest.php
@@ -124,7 +124,7 @@ class ManagerTest extends TestCase {
 		$this->assertEquals([], $this->manager->getAnnouncements());
 
 		$announcement = $this->manager->announce($subject, $message, $author, $time, []);
-		$announcement2 = $this->manager->announce($subject, $message, $author, $time, ['gid1', 'gid2']);
+		$announcement2 = $this->manager->announce($subject, $message, $author, $time + 2, ['gid1', 'gid2']);
 		$this->assertInternalType('int', $announcement['id']);
 		$this->assertGreaterThan(0, $announcement['id']);
 		$this->assertSame('subject &lt;html&gt;', $announcement['subject']);
@@ -182,7 +182,7 @@ class ManagerTest extends TestCase {
 		$this->assertEquals([], $this->manager->getAnnouncements());
 
 		$announcement = $this->manager->announce($subject, $message, $author, $time, []);
-		$announcement2 = $this->manager->announce($subject, $message, $author, $time, ['gid1', 'gid2']);
+		$announcement2 = $this->manager->announce($subject, $message, $author, $time + 2, ['gid1', 'gid2']);
 		$this->assertInternalType('int', $announcement['id']);
 		$this->assertGreaterThan(0, $announcement['id']);
 		$this->assertSame('subject &lt;html&gt;', $announcement['subject']);

--- a/tests/ManagerTest.php
+++ b/tests/ManagerTest.php
@@ -22,6 +22,8 @@
 namespace OCA\AnnouncementCenter\Tests;
 
 use OCA\AnnouncementCenter\Manager;
+use OCP\IGroupManager;
+use OCP\IUserSession;
 
 /**
  * Class ManagerTest
@@ -30,13 +32,30 @@ use OCA\AnnouncementCenter\Manager;
  * @group DB
  */
 class ManagerTest extends TestCase {
+
 	/** @var Manager */
 	protected $manager;
 
+	/** @var IGroupManager|\PHPUnit_Framework_MockObject_MockObject */
+	protected $groupManager;
+
+	/** @var IUserSession|\PHPUnit_Framework_MockObject_MockObject */
+	protected $userSession;
+
 	protected function setUp() {
 		parent::setUp();
+
+		$this->groupManager = $this->getMockBuilder('OCP\IGroupManager')
+			->disableOriginalConstructor()
+			->getMock();
+		$this->userSession = $this->getMockBuilder('OCP\IUserSession')
+			->disableOriginalConstructor()
+			->getMock();
+
 		$this->manager = new Manager(
-			\OC::$server->getDatabaseConnection()
+			\OC::$server->getDatabaseConnection(),
+			$this->groupManager,
+			$this->userSession
 		);
 	}
 
@@ -54,7 +73,7 @@ class ManagerTest extends TestCase {
 	 * @expectedCode 2
 	 */
 	public function testAnnounceNoSubject() {
-		$this->manager->announce('', '', '', 0);
+		$this->manager->announce('', '', '', 0, []);
 	}
 
 	/**
@@ -63,7 +82,7 @@ class ManagerTest extends TestCase {
 	 * @expectedCode 1
 	 */
 	public function testAnnounceSubjectTooLong() {
-		$this->manager->announce(str_repeat('a', 513), '', '', 0);
+		$this->manager->announce(str_repeat('a', 513), '', '', 0, []);
 	}
 
 	public function testAnnouncement() {
@@ -72,7 +91,7 @@ class ManagerTest extends TestCase {
 		$author = 'author';
 		$time = time() - 10;
 
-		$announcement = $this->manager->announce($subject, $message, $author, $time);
+		$announcement = $this->manager->announce($subject, $message, $author, $time, []);
 		$this->assertInternalType('int', $announcement['id']);
 		$this->assertGreaterThan(0, $announcement['id']);
 		$this->assertSame('subject &lt;html&gt;', $announcement['subject']);


### PR DESCRIPTION
Fix #4 

ToDo:
- [x] Option in the UI
- [x] Write/delete group-announcement links to/from database
- [x] Respect the setting on reading announcements (_ignoring admins_)
- [x] Update step that adds links for existing announcements
- [x] Fix activity/notification generation to respect the setting
- [x] Fix tests
- [x] Write tests for new code
- [x] Display :busts_in_silhouette: / :earth_africa: for admins 