### PR TITLE
Comments for announcements

### DIFF
--- a/appinfo/database.xml
+++ b/appinfo/database.xml
@@ -40,6 +40,13 @@
 				<type>clob</type>
 				<notnull>false</notnull>
 			</field>
+			<field>
+				<name>allow_comments</name>
+				<type>integer</type>
+				<notnull>false</notnull>
+				<length>1</length>
+				<default>1</default>
+			</field>
 		</declaration>
 	</table>
 

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -5,7 +5,7 @@
 	<description>An announcement center for Nextcloud</description>
 	<licence>AGPL</licence>
 	<author>Joas Schilling</author>
-	<version>1.3.0</version>
+	<version>1.4.0</version>
 	<namespace>AnnouncementCenter</namespace>
 
 	<category>other</category>
@@ -19,6 +19,10 @@
 		<owncloud min-version="9.1" max-version="9.2" />
 		<nextcloud min-version="10" max-version="11" />
 	</dependencies>
+
+	<types>
+		<logging/>
+	</types>
 
 	<repair-steps>
 		<post-migration>

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -5,7 +5,7 @@
 	<description>An announcement center for Nextcloud</description>
 	<licence>AGPL</licence>
 	<author>Joas Schilling</author>
-	<version>1.4.0</version>
+	<version>1.5.2</version>
 	<namespace>AnnouncementCenter</namespace>
 
 	<category>other</category>

--- a/css/comments.css
+++ b/css/comments.css
@@ -1,0 +1,133 @@
+/*
+ * Copyright (c) 2016
+ *
+ * This file is licensed under the Affero General Public License version 3
+ * or later.
+ *
+ * See the COPYING-README file.
+ *
+ */
+
+#commentsTabView .newCommentForm {
+	margin-bottom: 20px;
+}
+
+#commentsTabView .newCommentForm .message {
+	width: 90%;
+	resize: vertical;
+}
+
+#commentsTabView .newCommentForm .submitLoading {
+	background-position: left;
+}
+
+#commentsTabView .comment {
+	margin-bottom: 30px;
+}
+
+#commentsTabView .comment .avatar {
+	width: 28px;
+	height: 28px;
+	line-height: 28px;
+}
+
+#commentsTabView .comment {
+	position: relative;
+	z-index: 1;
+}
+
+#commentsTabView .comment.collapsed .message {
+	white-space: -moz-pre-wrap !important;  /* Mozilla, since 1999 */
+	white-space: -webkit-pre-wrap; /*Chrome & Safari */ 
+	white-space: -pre-wrap;      /* Opera 4-6 */
+	white-space: -o-pre-wrap;    /* Opera 7 */
+	white-space: pre-wrap;       /* css-3 */
+	word-wrap: break-word;       /* Internet Explorer 5.5+ */
+	word-break: break-all;
+	white-space: normal;
+}
+
+#commentsTabView .comment.collapsed .message {
+	max-height: 70px;
+	overflow: hidden;
+}
+
+#commentsTabView .comment .message-overlay {
+	display: none;
+}
+
+#commentsTabView .comment.collapsed .message-overlay {
+	display: block;
+    position: absolute;
+	z-index: 2;
+    height: 50px;
+    pointer-events: none;
+	left: 0;
+	right: 0;
+    bottom: 0;
+	background: -moz-linear-gradient(rgba(255,255,255,0), rgba(255,255,255,1));
+	background: -webkit-linear-gradient(rgba(255,255,255,0), rgba(255,255,255,1));
+	background: -o-linear-gradient(rgba(255,255,255,0), rgba(255,255,255,1));
+	background: -ms-linear-gradient(rgba(255,255,255,0), rgba(255,255,255,1));
+	background: linear-gradient(rgba(255,255,255,0), rgba(255,255,255,1));
+	filter: progid:DXImageTransform.Microsoft.gradient(GradientType=0,startColorstr='#00FFFFFF', endColorstr='#FFFFFFFF');
+    background-repeat: no-repeat;
+}
+
+#commentsTabView .authorRow>div {
+	display: inline-block;
+	vertical-align: middle;
+}
+
+#commentsTabView .comment .authorRow {
+	margin-bottom: 5px;
+	position: relative;
+}
+
+#commentsTabView .comment .author {
+	font-weight: bold;
+}
+
+#commentsTabView .comment .date {
+	position: absolute;
+	right: 0;
+}
+
+#commentsTabView .comment .action {
+	opacity: 0;
+	vertical-align: middle;
+	display: inline-block;
+}
+
+#commentsTabView .comment:hover .action {
+	opacity: 0.3;
+}
+
+#commentsTabView .comment .action:hover {
+	opacity: 1;
+}
+
+#commentsTabView .comment .action.delete {
+	position: absolute;
+	right: 0;
+}
+
+#commentsTabView .comment.disabled {
+	opacity: 0.3;
+}
+
+#commentsTabView .comment.disabled .action {
+	visibility: hidden;
+}
+
+#commentsTabView .message.error {
+	color: #e9322d;
+	border-color: #e9322d;
+	-webkit-box-shadow: 0 0 6px #f8b9b7;
+	-moz-box-shadow: 0 0 6px #f8b9b7;
+	box-shadow: 0 0 6px #f8b9b7;
+}
+
+.app-files .action-comment {
+	padding: 16px 14px;
+}

--- a/css/comments.css
+++ b/css/comments.css
@@ -8,43 +8,59 @@
  *
  */
 
+#commentsTabView .emptycontent {
+	margin-top: 0;
+}
+
 #commentsTabView .newCommentForm {
+	position: relative;
 	margin-bottom: 20px;
 }
 
 #commentsTabView .newCommentForm .message {
-	width: 90%;
-	resize: vertical;
+	width: calc(100% - 81px); /* 36 (left margin) + 30 (right padding) + 15 (right padding of surrounding box) */
+	margin-left: 36px;
+	padding-right: 30px;
+}
+
+#commentsTabView .newCommentForm .submit {
+	position: absolute;
+	top: 1px;
+	right: 8px;
+	width: 30px;
+	margin: 0;
+	padding: 9px;
+	background-color: transparent;
+	border: none;
+	opacity: .3;
+}
+#commentsTabView .newCommentForm .submit:hover,
+#commentsTabView .newCommentForm .submit:focus {
+	opacity: 1;
 }
 
 #commentsTabView .newCommentForm .submitLoading {
 	background-position: left;
 }
 
-#commentsTabView .comment {
-	margin-bottom: 30px;
-}
-
-#commentsTabView .comment .avatar {
-	width: 28px;
-	height: 28px;
-	line-height: 28px;
+#commentsTabView .newCommentForm .cancel {
+	margin-right: 6px;
 }
 
 #commentsTabView .comment {
 	position: relative;
 	z-index: 1;
+	margin-bottom: 30px;
+}
+
+#commentsTabView .comment .avatar {
+	width: 32px;
+	height: 32px;
+	line-height: 32px;
 }
 
 #commentsTabView .comment.collapsed .message {
-	white-space: -moz-pre-wrap !important;  /* Mozilla, since 1999 */
-	white-space: -webkit-pre-wrap; /*Chrome & Safari */ 
-	white-space: -pre-wrap;      /* Opera 4-6 */
-	white-space: -o-pre-wrap;    /* Opera 7 */
-	white-space: pre-wrap;       /* css-3 */
-	word-wrap: break-word;       /* Internet Explorer 5.5+ */
-	word-break: break-all;
-	white-space: normal;
+	white-space: pre-wrap;
 }
 
 #commentsTabView .comment.collapsed .message {
@@ -58,20 +74,20 @@
 
 #commentsTabView .comment.collapsed .message-overlay {
 	display: block;
-    position: absolute;
+	position: absolute;
 	z-index: 2;
-    height: 50px;
-    pointer-events: none;
+	height: 50px;
+	pointer-events: none;
 	left: 0;
 	right: 0;
-    bottom: 0;
+	bottom: 0;
 	background: -moz-linear-gradient(rgba(255,255,255,0), rgba(255,255,255,1));
 	background: -webkit-linear-gradient(rgba(255,255,255,0), rgba(255,255,255,1));
 	background: -o-linear-gradient(rgba(255,255,255,0), rgba(255,255,255,1));
 	background: -ms-linear-gradient(rgba(255,255,255,0), rgba(255,255,255,1));
 	background: linear-gradient(rgba(255,255,255,0), rgba(255,255,255,1));
 	filter: progid:DXImageTransform.Microsoft.gradient(GradientType=0,startColorstr='#00FFFFFF', endColorstr='#FFFFFFFF');
-    background-repeat: no-repeat;
+	background-repeat: no-repeat;
 }
 
 #commentsTabView .authorRow>div {
@@ -80,17 +96,24 @@
 }
 
 #commentsTabView .comment .authorRow {
-	margin-bottom: 5px;
 	position: relative;
 }
 
-#commentsTabView .comment .author {
-	font-weight: bold;
+#commentsTabView .comment .author,
+#commentsTabView .comment .date {
+	opacity: .5;
 }
-
+#commentsTabView .comment .author {
+	margin-left: 5px;
+}
 #commentsTabView .comment .date {
 	position: absolute;
 	right: 0;
+	top: 5px;
+}
+
+#commentsTabView .comments li .message {
+	padding-left: 40px;
 }
 
 #commentsTabView .comment .action {

--- a/css/style.css
+++ b/css/style.css
@@ -48,3 +48,7 @@
 #app-sidebar .tab {
 	padding: 15px
 }
+
+#app input[type="text"] {
+	box-sizing: content-box;
+}

--- a/css/style.css
+++ b/css/style.css
@@ -44,3 +44,7 @@
 .announcementcenter .section:hover .delete-link {
 	display: inline;
 }
+
+#app-sidebar .tab {
+	padding: 15px
+}

--- a/js/commentcollection.js
+++ b/js/commentcollection.js
@@ -1,0 +1,157 @@
+(function(OC, OCA) {
+
+	/**
+	 * @class OCA.AnnouncementCenter.Comments.CommentCollection
+	 * @classdesc
+	 *
+	 * Collection of comments assigned to a file
+	 *
+	 */
+	var CommentCollection = OC.Backbone.Collection.extend(
+		/** @lends OCA.AnnouncementCenter.Comments.CommentCollection.prototype */ {
+
+		sync: OC.Backbone.davSync,
+
+		model: OCA.AnnouncementCenter.Comments.CommentModel,
+
+		/**
+		 * Object type
+		 *
+		 * @type string
+		 */
+		_objectType: 'announcement',
+
+		/**
+		 * Object id
+		 *
+		 * @type string
+		 */
+		_objectId: null,
+
+		/**
+		 * True if there are no more page results left to fetch
+		 *
+		 * @type bool
+		 */
+		_endReached: false,
+
+		/**
+		 * Number of comments to fetch per page
+		 *
+		 * @type int
+		 */
+		_limit : 20,
+
+		/**
+		 * Initializes the collection
+		 *
+		 * @param {string} [options.objectType] object type
+		 * @param {string} [options.objectId] object id
+		 */
+		initialize: function(models, options) {
+			options = options || {};
+			if (options.objectType) {
+				this._objectType = options.objectType;
+			}
+			if (options.objectId) {
+				this._objectId = options.objectId;
+			}
+		},
+
+		url: function() {
+			return OC.linkToRemote('dav') + '/comments/' +
+				encodeURIComponent(this._objectType) + '/' +
+				encodeURIComponent(this._objectId) + '/';
+		},
+
+		setObjectId: function(objectId) {
+			this._objectId = objectId;
+		},
+
+		hasMoreResults: function() {
+			return !this._endReached;
+		},
+
+		reset: function() {
+			this._endReached = false;
+			this._summaryModel = null;
+			return OC.Backbone.Collection.prototype.reset.apply(this, arguments);
+		},
+
+		/**
+		 * Fetch the next set of results
+		 */
+		fetchNext: function(options) {
+			var self = this;
+			if (!this.hasMoreResults()) {
+				return null;
+			}
+
+			var body = '<?xml version="1.0" encoding="utf-8" ?>\n' +
+				'<oc:filter-comments xmlns:D="DAV:" xmlns:oc="http://owncloud.org/ns">\n' +
+				// load one more so we know there is more
+				'    <oc:limit>' + (this._limit + 1) + '</oc:limit>\n' +
+				'    <oc:offset>' + this.length + '</oc:offset>\n' +
+				'</oc:filter-comments>\n';
+
+			options = options || {};
+			var success = options.success;
+			options = _.extend({
+				remove: false,
+				parse: true,
+				data: body,
+				davProperties: CommentCollection.prototype.model.prototype.davProperties,
+				success: function(resp) {
+					if (resp.length <= self._limit) {
+						// no new entries, end reached
+						self._endReached = true;
+					} else {
+						// remove last entry, for next page load
+						resp = _.initial(resp);
+					}
+					if (!self.set(resp, options)) {
+						return false;
+					}
+					if (success) {
+						success.apply(null, arguments);
+					}
+					self.trigger('sync', 'REPORT', self, options);
+				}
+			}, options);
+
+			return this.sync('REPORT', this, options);
+		},
+
+		/**
+		 * Returns the matching summary model
+		 *
+		 * @return {OCA.AnnouncementCenter.Comments.CommentSummaryModel} summary model
+		 */
+		getSummaryModel: function() {
+			if (!this._summaryModel) {
+				this._summaryModel = new OCA.AnnouncementCenter.Comments.CommentSummaryModel({
+					id: this._objectId,
+					objectType: this._objectType
+				});
+			}
+			return this._summaryModel;
+		},
+
+		/**
+		 * Updates the read marker for this comment thread
+		 *
+		 * @param {Date} [date] optional date, defaults to now
+		 * @param {Object} [options] backbone options
+		 */
+		updateReadMarker: function(date, options) {
+			options = options || {};
+
+			return this.getSummaryModel().save({
+				readMarker: (date || new Date()).toUTCString()
+			}, options);
+		}
+	});
+
+	OCA.AnnouncementCenter.Comments.CommentCollection = CommentCollection;
+})(OC, OCA);
+

--- a/js/commentmodel.js
+++ b/js/commentmodel.js
@@ -1,0 +1,49 @@
+
+(function(OC, OCA) {
+	var NS_OWNCLOUD = 'http://owncloud.org/ns';
+	/**
+	 * @class OCA.AnnouncementCenter.Comments.CommentModel
+	 * @classdesc
+	 *
+	 * Comment
+	 *
+	 */
+	var CommentModel = OC.Backbone.Model.extend(
+		/** @lends OCA.Comments.CommentModel.prototype */ {
+		sync: OC.Backbone.davSync,
+
+		defaults: {
+			actorType: 'users',
+			objectType: 'announcement'
+		},
+
+		davProperties: {
+			'id': '{' + NS_OWNCLOUD + '}id',
+			'message': '{' + NS_OWNCLOUD + '}message',
+			'actorType': '{' + NS_OWNCLOUD + '}actorType',
+			'actorId': '{' + NS_OWNCLOUD + '}actorId',
+			'actorDisplayName': '{' + NS_OWNCLOUD + '}actorDisplayName',
+			'creationDateTime': '{' + NS_OWNCLOUD + '}creationDateTime',
+			'objectType': '{' + NS_OWNCLOUD + '}objectType',
+			'objectId': '{' + NS_OWNCLOUD + '}objectId',
+			'isUnread': '{' + NS_OWNCLOUD + '}isUnread'
+		},
+
+		parse: function(data) {
+			return {
+				id: data.id,
+				message: data.message,
+				actorType: data.actorType,
+				actorId: data.actorId,
+				actorDisplayName: data.actorDisplayName,
+				creationDateTime: data.creationDateTime,
+				objectType: data.objectType,
+				objectId: data.objectId,
+				isUnread: (data.isUnread === 'true')
+			};
+		}
+	});
+
+	OCA.AnnouncementCenter.Comments.CommentModel = CommentModel;
+})(OC, OCA);
+

--- a/js/commentstabview.js
+++ b/js/commentstabview.js
@@ -1,0 +1,440 @@
+/*
+ * Copyright (c) 2016
+ *
+ * This file is licensed under the Affero General Public License version 3
+ * or later.
+ *
+ * See the COPYING-README file.
+ *
+ */
+
+/* global Handlebars, escapeHTML */
+
+(function(OC, OCA) {
+	var TEMPLATE =
+		'<ul class="comments">' +
+		'</ul>' +
+		'<div class="empty hidden">{{emptyResultLabel}}</div>' +
+		'<input type="button" class="showMore hidden" value="{{moreLabel}}"' +
+		' name="show-more" id="show-more" />' +
+		'<div class="loading hidden" style="height: 50px"></div>';
+
+	var EDIT_COMMENT_TEMPLATE =
+		'<div class="newCommentRow comment" data-id="{{id}}">' +
+		'    <div class="authorRow">' +
+		'        {{#if avatarEnabled}}' +
+		'        <div class="avatar" data-username="{{actorId}}"></div>' +
+		'        {{/if}}' +
+		'        <div class="author">{{actorDisplayName}}</div>' +
+		'{{#if isEditMode}}' +
+		'        <a href="#" class="action delete icon icon-delete has-tooltip" title="{{deleteTooltip}}"></a>' +
+		'{{/if}}' +
+		'    </div>' +
+		'    <form class="newCommentForm">' +
+		'        <textarea class="message" placeholder="{{newMessagePlaceholder}}">{{{message}}}</textarea>' +
+		'        <input class="submit" type="submit" value="{{submitText}}" />' +
+		'{{#if isEditMode}}' +
+		'        <input class="cancel" type="button" value="{{cancelText}}" />' +
+		'{{/if}}' +
+		'        <div class="submitLoading icon-loading-small hidden"></div>'+
+		'    </form>' +
+		'</div>';
+
+	var COMMENT_TEMPLATE =
+		'<li class="comment{{#if isUnread}} unread{{/if}}{{#if isLong}} collapsed{{/if}}" data-id="{{id}}">' +
+		'    <div class="authorRow">' +
+		'        {{#if avatarEnabled}}' +
+		'        <div class="avatar" {{#if actorId}}data-username="{{actorId}}"{{/if}}> </div>' +
+		'        {{/if}}' +
+		'        <div class="author">{{actorDisplayName}}</div>' +
+		'{{#if isUserAuthor}}' +
+		'        <a href="#" class="action edit icon icon-rename has-tooltip" title="{{editTooltip}}"></a>' +
+		'{{/if}}' +
+		'        <div class="date has-tooltip" title="{{altDate}}">{{date}}</div>' +
+		'    </div>' +
+		'    <div class="message">{{{formattedMessage}}}</div>' +
+		'{{#if isLong}}' +
+		'    <div class="message-overlay"></div>' +
+		'{{/if}}' +
+		'</li>';
+
+	/**
+	 * @memberof OCA.AnnouncementCenter.Comments
+	 */
+	OCA.AnnouncementCenter.Comments.CommentsTabView = {
+		id: 'commentsTabView',
+		className: 'tab commentsTabView',
+		currentId: 0,
+
+		_commentMaxLength: 1000,
+
+		initialize: function() {
+			this.$el = $('#commentsTabView');
+
+			this.collection = new OCA.AnnouncementCenter.Comments.CommentCollection();
+			this.collection.on('request', this._onRequest, this);
+			this.collection.on('sync', this._onEndRequest, this);
+			this.collection.on('add', this._onAddModel, this);
+
+			this._avatarsEnabled = !!OC.config.enable_avatars;
+
+			this._commentMaxThreshold = this._commentMaxLength * 0.9;
+
+			// TODO: error handling
+			_.bindAll(this, '_onTypeComment');
+		},
+
+		template: function(params) {
+			if (!this._template) {
+				this._template = Handlebars.compile(TEMPLATE);
+			}
+			var currentUser = OC.getCurrentUser();
+			return this._template(_.extend({
+				avatarEnabled: this._avatarsEnabled,
+				actorId: currentUser.uid,
+				actorDisplayName: currentUser.displayName
+			}, params));
+		},
+
+		editCommentTemplate: function(params) {
+			if (!this._editCommentTemplate) {
+				this._editCommentTemplate = Handlebars.compile(EDIT_COMMENT_TEMPLATE);
+			}
+			var currentUser = OC.getCurrentUser();
+			var el = this._editCommentTemplate(_.extend({
+				avatarEnabled: this._avatarsEnabled,
+				actorId: currentUser.uid,
+				actorDisplayName: currentUser.displayName,
+				newMessagePlaceholder: t('comments', 'Type in a new comment...'),
+				deleteTooltip: t('comments', 'Delete comment'),
+				submitText: t('comments', 'Post'),
+				cancelText: t('comments', 'Cancel')
+			}, params));
+			var $el = $(el);
+
+			$el.find('.action.delete').on('click', _.bind(this._onClickDeleteComment, this));
+			$el.find('.cancel').on('click', _.bind(this._onClickCloseComment, this));
+			$el.find('.newCommentForm').on('submit', _.bind(this._onSubmitComment, this));
+
+			return $el;
+		},
+
+		commentTemplate: function(params) {
+			if (!this._commentTemplate) {
+				this._commentTemplate = Handlebars.compile(COMMENT_TEMPLATE);
+			}
+
+			params = _.extend({
+				avatarEnabled: this._avatarsEnabled,
+				editTooltip: t('comments', 'Edit comment'),
+				isUserAuthor: OC.getCurrentUser().uid === params.actorId,
+				isLong: this._isLong(params.message)
+			}, params);
+
+			if (params.actorType === 'deleted_users') {
+				// makes the avatar a X
+				params.actorId = null;
+				params.actorDisplayName = t('comments', '[Deleted user]');
+			}
+
+			return this._commentTemplate(params);
+		},
+
+		getLabel: function() {
+			return t('comments', 'Comments');
+		},
+
+		setObjectId: function(announcementId) {
+			if (this.currentId === announcementId) {
+				return;
+			}
+
+			if (announcementId === 0) {
+				$('#app-content').removeClass('with-app-sidebar');
+				$('#app-sidebar').addClass('disappear');
+			} else {
+				$('#app-content').addClass('with-app-sidebar');
+				$('#app-sidebar').removeClass('disappear');
+
+				this.render();
+				this.collection.setObjectId(announcementId);
+				// reset to first page
+				this.collection.reset([], {silent: true});
+				this.nextPage();
+				this.currentId = announcementId;
+			}
+
+		},
+
+		render: function() {
+			this.$el.html(this.template({
+				emptyResultLabel: t('comments', 'No other comments available'),
+				moreLabel: t('comments', 'More comments...')
+			}));
+			this.$el.find('.comments').before(this.editCommentTemplate({}));
+			this.$el.find('.has-tooltip').tooltip();
+			this.$container = this.$el.find('ul.comments');
+			if (this._avatarsEnabled) {
+				this.$el.find('.avatar').avatar(OC.getCurrentUser().uid, 28);
+			}
+			this.$el.find('textarea').on('keydown input change', this._onTypeComment);
+			this.$el.find('.showMore').on('click', this._onClickShowMore);
+		},
+
+		_formatItem: function(commentModel) {
+			var timestamp = new Date(commentModel.get('creationDateTime')).getTime();
+			var data = _.extend({
+				date: OC.Util.relativeModifiedDate(timestamp),
+				altDate: OC.Util.formatDate(timestamp),
+				formattedMessage: this._formatMessage(commentModel.get('message'))
+			}, commentModel.attributes);
+			return data;
+		},
+
+		_toggleLoading: function(state) {
+			this._loading = state;
+			this.$el.find('.loading').toggleClass('hidden', !state);
+		},
+
+		_onRequest: function(type) {
+			if (type === 'REPORT') {
+				this._toggleLoading(true);
+				this.$el.find('.showMore').addClass('hidden');
+			}
+		},
+
+		_onEndRequest: function(type) {
+			this._toggleLoading(false);
+			this.$el.find('.empty').toggleClass('hidden', !!this.collection.length);
+			this.$el.find('.showMore').toggleClass('hidden', !this.collection.hasMoreResults());
+
+			if (type !== 'REPORT') {
+				return;
+			}
+
+			// find first unread comment
+			var firstUnreadComment = this.collection.findWhere({isUnread: true});
+			if (firstUnreadComment) {
+				// update read marker
+				this.collection.updateReadMarker();
+			}
+		},
+
+		_onAddModel: function(model, collection, options) {
+			var $el = $(this.commentTemplate(this._formatItem(model)));
+			if (!_.isUndefined(options.at) && collection.length > 1) {
+				this.$container.find('li').eq(options.at).before($el);
+			} else {
+				this.$container.append($el);
+			}
+
+			this._postRenderItem($el);
+		},
+
+		_postRenderItem: function($el) {
+			$el.find('.has-tooltip').tooltip();
+
+			$el.find('.action.edit').on('click', _.bind(this._onClickEditComment, this));
+			$el.on('click', _.bind(this._onClickComment, this));
+
+			if(this._avatarsEnabled) {
+				$el.find('.avatar').each(function() {
+					var $this = $(this);
+					$this.avatar($this.attr('data-username'), 28);
+				});
+			}
+		},
+
+		/**
+		 * Convert a message to be displayed in HTML,
+		 * converts newlines to <br> tags.
+		 */
+		_formatMessage: function(message) {
+			return escapeHTML(message).replace(/\n/g, '<br/>');
+		},
+
+		nextPage: function() {
+			if (this._loading || !this.collection.hasMoreResults()) {
+				return;
+			}
+
+			this.collection.fetchNext();
+		},
+
+		_onClickEditComment: function(ev) {
+			ev.preventDefault();
+			var $comment = $(ev.target).closest('.comment');
+			var commentId = $comment.data('id');
+			var commentToEdit = this.collection.get(commentId);
+			var $formRow = $(this.editCommentTemplate(_.extend({
+				isEditMode: true,
+				submitText: t('comments', 'Save')
+			}, commentToEdit.attributes)));
+
+			$comment.addClass('hidden').removeClass('collapsed');
+			// spawn form
+			$comment.after($formRow);
+			$formRow.data('commentEl', $comment);
+			$formRow.find('textarea').on('keydown input change', this._onTypeComment);
+
+			// copy avatar element from original to avoid flickering
+			$formRow.find('.avatar').replaceWith($comment.find('.avatar').clone());
+			$formRow.find('.has-tooltip').tooltip();
+
+			return false;
+		},
+
+		_onTypeComment: function(ev) {
+			var $field = $(ev.target);
+			var len = $field.val().length;
+			var $submitButton = $field.data('submitButtonEl');
+			if (!$submitButton) {
+				$submitButton = $field.closest('form').find('.submit');
+				$field.data('submitButtonEl', $submitButton);
+			}
+			$field.tooltip('hide');
+			if (len > this._commentMaxThreshold) {
+				$field.attr('data-original-title', t('comments', 'Allowed characters {count} of {max}', {count: len, max: this._commentMaxLength}));
+				$field.tooltip({trigger: 'manual'});
+				$field.tooltip('show');
+				$field.addClass('error');
+			}
+
+			var limitExceeded = (len > this._commentMaxLength);
+			$field.toggleClass('error', limitExceeded);
+			$submitButton.prop('disabled', limitExceeded);
+
+			//submits form on ctrl+Enter or cmd+Enter
+			if (ev.keyCode === 13 && (ev.ctrlKey || ev.metaKey)) {
+				$submitButton.click();
+			}
+		},
+
+		_onClickComment: function(ev) {
+			var $row = $(ev.target);
+			if (!$row.is('.comment')) {
+				$row = $row.closest('.comment');
+			}
+			$row.removeClass('collapsed');
+		},
+
+		_onClickCloseComment: function(ev) {
+			ev.preventDefault();
+			var $row = $(ev.target).closest('.comment');
+			$row.data('commentEl').removeClass('hidden');
+			$row.remove();
+			return false;
+		},
+
+		_onClickDeleteComment: function(ev) {
+			ev.preventDefault();
+			var $comment = $(ev.target).closest('.comment');
+			var commentId = $comment.data('id');
+			var $loading = $comment.find('.submitLoading');
+
+			$comment.addClass('disabled');
+			$loading.removeClass('hidden');
+			this.collection.get(commentId).destroy({
+				success: function() {
+					$comment.data('commentEl').remove();
+					$comment.remove();
+				},
+				error: function() {
+					$loading.addClass('hidden');
+					$comment.removeClass('disabled');
+					OC.Notification.showTemporary(t('comments', 'Error occurred while retrieving comment with id {id}', {id: commentId}));
+				}
+			});
+
+
+			return false;
+		},
+
+		_onClickShowMore: function(ev) {
+			ev.preventDefault();
+			this.nextPage();
+		},
+
+		_onSubmitComment: function(e) {
+			var self = this;
+			var $form = $(e.target);
+			var commentId = $form.closest('.comment').data('id');
+			var currentUser = OC.getCurrentUser();
+			var $submit = $form.find('.submit');
+			var $loading = $form.find('.submitLoading');
+			var $textArea = $form.find('textarea');
+			var message = $textArea.val().trim();
+			e.preventDefault();
+
+			if (!message.length || message.length > this._commentMaxLength) {
+				return;
+			}
+
+			$textArea.prop('disabled', true);
+			$submit.addClass('hidden');
+			$loading.removeClass('hidden');
+
+			if (commentId) {
+				// edit mode
+				var comment = this.collection.get(commentId);
+				comment.save({
+					message: $textArea.val()
+				}, {
+					success: function(model) {
+						var $row = $form.closest('.comment');
+						$submit.removeClass('hidden');
+						$loading.addClass('hidden');
+						$row.data('commentEl')
+							.removeClass('hidden')
+							.find('.message')
+							.html(self._formatMessage(model.get('message')));
+						$row.remove();
+					},
+					error: function() {
+						$submit.removeClass('hidden');
+						$loading.addClass('hidden');
+						$textArea.prop('disabled', false);
+
+						OC.Notification.showTemporary(t('comments', 'Error occurred while updating comment with id {id}', {id: commentId}));
+					}
+				});
+			} else {
+				this.collection.create({
+					actorId: currentUser.uid,
+					actorDisplayName: currentUser.displayName,
+					actorType: 'users',
+					verb: 'comment',
+					message: $textArea.val(),
+					creationDateTime: (new Date()).toUTCString()
+				}, {
+					at: 0,
+					// wait for real creation before adding
+					wait: true,
+					success: function() {
+						$submit.removeClass('hidden');
+						$loading.addClass('hidden');
+						$textArea.val('').prop('disabled', false);
+					},
+					error: function() {
+						$submit.removeClass('hidden');
+						$loading.addClass('hidden');
+						$textArea.prop('disabled', false);
+
+						OC.Notification.showTemporary(t('comments', 'Error occurred while posting comment'));
+					}
+				});
+			}
+
+			return false;
+		},
+
+		/**
+		 * Returns whether the given message is long and needs
+		 * collapsing
+		 */
+		_isLong: function(message) {
+			return message.length > 250 || (message.match(/\n/g) || []).length > 1;
+		}
+	};
+})(OC, OCA);
+

--- a/js/commentstabview.js
+++ b/js/commentstabview.js
@@ -329,7 +329,8 @@
 
 		_onClickDeleteComment: function(ev) {
 			ev.preventDefault();
-			var $comment = $(ev.target).closest('.comment');
+			var self = this,
+				$comment = $(ev.target).closest('.comment');
 			var commentId = $comment.data('id');
 			var $loading = $comment.find('.submitLoading');
 
@@ -339,6 +340,7 @@
 				success: function() {
 					$comment.data('commentEl').remove();
 					$comment.remove();
+					self._updateCommentCount(self.currentId, -1);
 				},
 				error: function() {
 					$loading.addClass('hidden');
@@ -415,6 +417,7 @@
 						$submit.removeClass('hidden');
 						$loading.addClass('hidden');
 						$textArea.val('').prop('disabled', false);
+						self._updateCommentCount(self.currentId, 1);
 					},
 					error: function() {
 						$submit.removeClass('hidden');
@@ -427,6 +430,15 @@
 			}
 
 			return false;
+		},
+
+		_updateCommentCount: function(announcement, diff) {
+			var $announcement = $('.section[data-announcement-id=' + announcement + ']'),
+				$details = $announcement.find('.comment-details'),
+				newCount = parseInt($details.attr('data-count'), 10) + diff;
+
+			$details.attr('data-count', newCount);
+			$details.text(n('announcementcenter', '%n comment', '%n comments', newCount));
 		},
 
 		/**

--- a/js/commentstabview.js
+++ b/js/commentstabview.js
@@ -161,9 +161,9 @@
 				// reset to first page
 				this.collection.reset([], {silent: true});
 				this.nextPage();
-				this.currentId = announcementId;
 			}
 
+			this.currentId = announcementId;
 		},
 
 		render: function() {

--- a/js/commentstabview.js
+++ b/js/commentstabview.js
@@ -14,7 +14,8 @@
 	var TEMPLATE =
 		'<ul class="comments">' +
 		'</ul>' +
-		'<div class="empty hidden">{{emptyResultLabel}}</div>' +
+		'<div class="emptycontent hidden"><div class="icon-comment"></div>' +
+		'<p>{{emptyResultLabel}}</p></div>' +
 		'<input type="button" class="showMore hidden" value="{{moreLabel}}"' +
 		' name="show-more" id="show-more" />' +
 		'<div class="loading hidden" style="height: 50px"></div>';
@@ -31,10 +32,10 @@
 		'{{/if}}' +
 		'    </div>' +
 		'    <form class="newCommentForm">' +
-		'        <textarea class="message" placeholder="{{newMessagePlaceholder}}">{{{message}}}</textarea>' +
-		'        <input class="submit" type="submit" value="{{submitText}}" />' +
+		'        <input type="text" class="message" placeholder="{{newMessagePlaceholder}}" value="{{{message}}}" />' +
+		'        <input class="submit icon-confirm" type="submit" value="" />' +
 		'{{#if isEditMode}}' +
-		'        <input class="cancel" type="button" value="{{cancelText}}" />' +
+		'        <input class="cancel pull-right" type="button" value="{{cancelText}}" />' +
 		'{{/if}}' +
 		'        <div class="submitLoading icon-loading-small hidden"></div>'+
 		'    </form>' +
@@ -105,7 +106,7 @@
 				avatarEnabled: this._avatarsEnabled,
 				actorId: currentUser.uid,
 				actorDisplayName: currentUser.displayName,
-				newMessagePlaceholder: t('comments', 'Type in a new comment...'),
+				newMessagePlaceholder: t('comments', 'New comment …'),
 				deleteTooltip: t('comments', 'Delete comment'),
 				submitText: t('comments', 'Post'),
 				cancelText: t('comments', 'Cancel')
@@ -168,16 +169,16 @@
 
 		render: function() {
 			this.$el.html(this.template({
-				emptyResultLabel: t('comments', 'No other comments available'),
-				moreLabel: t('comments', 'More comments...')
+				emptyResultLabel: t('comments', 'No comments yet, start the conversation!'),
+				moreLabel: t('comments', 'More comments …')
 			}));
 			this.$el.find('.comments').before(this.editCommentTemplate({}));
 			this.$el.find('.has-tooltip').tooltip();
 			this.$container = this.$el.find('ul.comments');
 			if (this._avatarsEnabled) {
-				this.$el.find('.avatar').avatar(OC.getCurrentUser().uid, 28);
+				this.$el.find('.avatar').avatar(OC.getCurrentUser().uid, 32);
 			}
-			this.$el.find('textarea').on('keydown input change', this._onTypeComment);
+			this.$el.find('.message').on('keydown input change', this._onTypeComment);
 			this.$el.find('.showMore').on('click', this._onClickShowMore);
 		},
 
@@ -205,7 +206,7 @@
 
 		_onEndRequest: function(type) {
 			this._toggleLoading(false);
-			this.$el.find('.empty').toggleClass('hidden', !!this.collection.length);
+			this.$el.find('.emptycontent').toggleClass('hidden', !!this.collection.length);
 			this.$el.find('.showMore').toggleClass('hidden', !this.collection.hasMoreResults());
 
 			if (type !== 'REPORT') {
@@ -240,7 +241,7 @@
 			if(this._avatarsEnabled) {
 				$el.find('.avatar').each(function() {
 					var $this = $(this);
-					$this.avatar($this.attr('data-username'), 28);
+					$this.avatar($this.attr('data-username'), 32);
 				});
 			}
 		},
@@ -362,7 +363,7 @@
 			var currentUser = OC.getCurrentUser();
 			var $submit = $form.find('.submit');
 			var $loading = $form.find('.submitLoading');
-			var $textArea = $form.find('textarea');
+			var $textArea = $form.find('.message');
 			var message = $textArea.val().trim();
 			e.preventDefault();
 

--- a/js/commentsummarymodel.js
+++ b/js/commentsummarymodel.js
@@ -1,0 +1,56 @@
+
+(function(OC, OCA) {
+	var NS_OWNCLOUD = 'http://owncloud.org/ns';
+	/**
+	 * @class OCA.AnnouncementCenter.Comments.CommentSummaryModel
+	 * @classdesc
+	 *
+	 * Model containing summary information related to comments
+	 * like the read marker. 
+	 *
+	 */
+	var CommentSummaryModel = OC.Backbone.Model.extend(
+		/** @lends OCA.AnnouncementCenter.Comments.CommentSummaryModel.prototype */ {
+		sync: OC.Backbone.davSync,
+
+		/**
+		 * Object type
+		 *
+		 * @type string
+		 */
+		_objectType: 'announcement',
+
+		/**
+		 * Object id
+		 *
+		 * @type string
+		 */
+		_objectId: null,
+
+		davProperties: {
+			'readMarker': '{' + NS_OWNCLOUD + '}readMarker'
+		},
+
+		/**
+		 * Initializes the summary model
+		 *
+		 * @param {string} [options.objectType] object type
+		 * @param {string} [options.objectId] object id
+		 */
+		initialize: function(attrs, options) {
+			options = options || {};
+			if (options.objectType) {
+				this._objectType = options.objectType;
+			}
+		},
+
+		url: function() {
+			return OC.linkToRemote('dav') + '/comments/' +
+				encodeURIComponent(this._objectType) + '/' +
+				encodeURIComponent(this._objectId) + '/';
+		}
+	});
+
+	OCA.AnnouncementCenter.Comments.CommentSummaryModel = CommentSummaryModel;
+})(OC, OCA);
+

--- a/js/script.js
+++ b/js/script.js
@@ -30,7 +30,7 @@
 		handlebarTemplate: '<div class="section" data-announcement-id="{{{announcementId}}}">' +
 				'<h2>{{{subject}}}</h2>' +
 				'<em>' +
-					'{{time}} {{author}} ' +
+					'{{time}} {{{author}}} ' +
 					'{{#if isAdmin}}' +
 						'<span class="visibility has-tooltip" title="{{{visibilityString}}}">' +
 							'{{#if visibilityEveryone}}' +

--- a/js/script.js
+++ b/js/script.js
@@ -69,6 +69,9 @@
 			this.loadAnnouncements();
 
 			var self = this;
+			$('#announcement_options_button').on('click', function() {
+				$('#announcement_options').toggleClass('hidden');
+			});
 			$('#groups').each(function (index, element) {
 				self.setupGroupsSelect($(element));
 			});

--- a/js/script.js
+++ b/js/script.js
@@ -39,6 +39,7 @@
 								'<img src="' + OC.imagePath('core', 'places/contacts-dark') + '">' +
 							'{{/if}}' +
 						'</span>' +
+						'{{#if comments}}<span class="comment-details" data-count="{{num_comments}}">{{comments}}</span>{{/if}}' +
 						'<span class="delete-link">' +
 							' — ' +
 							'<a href="#" data-announcement-id="{{{announcementId}}}">' +
@@ -81,8 +82,7 @@
 			var $element = $(event.currentTarget),
 				announcementId = $element.data('announcement-id');
 
-			console.log(this.announcements);
-			if (this.announcements[announcementId]['comments']) {
+			if (this.announcements[announcementId]['comments'] !== false) {
 				this.commentsTabView.setObjectId(announcementId);
 			} else {
 				this.commentsTabView.setObjectId(0);
@@ -195,6 +195,8 @@
 				author: t('announcementcenter', 'by {author}', announcement),
 				subject: announcement.subject,
 				message: announcement.message,
+				comments: (announcement.comments !== false) ? n('announcementcenter', '%n comment', '%n comments', announcement.comments) : false,
+				num_comments: (announcement.comments !== false) ? announcement.comments : false,
 				visibilityEveryone: null,
 				visibilityString: null,
 				announcementId: announcement.id,

--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -71,8 +71,14 @@ class Application extends App {
 	protected function registerCommentsEntity() {
 		$this->getContainer()->getServer()->getEventDispatcher()->addListener(CommentsEntityEvent::EVENT_ENTITY, function(CommentsEntityEvent $event) {
 			$event->addEntityCollection('announcement', function($name) {
-				// TODO check for existance with the manager
-				return true;
+				/** @var \OCA\AnnouncementCenter\Manager $manager */
+				$manager = $this->getContainer()->query('OCA\AnnouncementCenter\Manager');
+				try {
+					$announcement = $manager->getAnnouncement((int) $name);
+				} catch (\InvalidArgumentException $e) {
+					return false;
+				}
+				return $announcement['comments'];
 			});
 		});
 	}

--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -24,6 +24,7 @@
 namespace OCA\AnnouncementCenter\AppInfo;
 
 use OCP\AppFramework\App;
+use OCP\Comments\CommentsEntityEvent;
 
 class Application extends App {
 	public function __construct (array $urlParams = array()) {
@@ -38,6 +39,7 @@ class Application extends App {
 		$this->registerAdminPanel();
 		$this->registerActivityExtension();
 		$this->registerNotificationNotifier();
+		$this->registerCommentsEntity();
 	}
 
 	protected function registerNavigationEntry() {
@@ -63,6 +65,15 @@ class Application extends App {
 	protected function registerActivityExtension() {
 		$this->getContainer()->getServer()->getActivityManager()->registerExtension(function() {
 			return $this->getContainer()->query('OCA\AnnouncementCenter\Activity\Extension');
+		});
+	}
+
+	protected function registerCommentsEntity() {
+		$this->getContainer()->getServer()->getEventDispatcher()->addListener(CommentsEntityEvent::EVENT_ENTITY, function(CommentsEntityEvent $event) {
+			$event->addEntityCollection('announcement', function($name) {
+				// TODO check for existance with the manager
+				return true;
+			});
 		});
 	}
 

--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -78,7 +78,7 @@ class Application extends App {
 				} catch (\InvalidArgumentException $e) {
 					return false;
 				}
-				return $announcement['comments'];
+				return $announcement['comments'] !== false;
 			});
 		});
 	}

--- a/lib/Controller/AdminController.php
+++ b/lib/Controller/AdminController.php
@@ -56,6 +56,7 @@ class AdminController extends Controller {
 			'adminGroups' => $adminGroups,
 			'createActivities' => $this->config->getAppValue('announcementcenter', 'create_activities', 'yes') === 'yes',
 			'createNotifications' => $this->config->getAppValue('announcementcenter', 'create_notifications', 'yes') === 'yes',
+			'allowComments' => $this->config->getAppValue('announcementcenter', 'allow_comments', 'yes') === 'yes',
 		], 'blank');
 	}
 }

--- a/lib/Controller/PageController.php
+++ b/lib/Controller/PageController.php
@@ -38,14 +38,10 @@ use OCP\IRequest;
 use OCP\IUser;
 use OCP\IUserManager;
 use OCP\IUserSession;
-use OCP\Notification\IManager as INotificationManager;
 
 class PageController extends Controller {
 	/** @var int */
 	const PAGE_LIMIT = 5;
-
-	/** @var INotificationManager */
-	protected $notificationManager;
 
 	/** @var IJobList */
 	protected $jobList;
@@ -78,7 +74,6 @@ class PageController extends Controller {
 	 * @param IGroupManager $groupManager
 	 * @param IUserManager $userManager
 	 * @param IJobList $jobList
-	 * @param INotificationManager $notificationManager
 	 * @param IL10N $l
 	 * @param Manager $manager
 	 * @param IConfig $config
@@ -90,7 +85,6 @@ class PageController extends Controller {
 								IGroupManager $groupManager,
 								IUserManager $userManager,
 								IJobList $jobList,
-								INotificationManager $notificationManager,
 								IL10N $l,
 								Manager $manager,
 								IConfig $config,
@@ -101,7 +95,6 @@ class PageController extends Controller {
 		$this->groupManager = $groupManager;
 		$this->userManager = $userManager;
 		$this->jobList = $jobList;
-		$this->notificationManager = $notificationManager;
 		$this->l = $l;
 		$this->manager = $manager;
 		$this->config = $config;
@@ -197,11 +190,6 @@ class PageController extends Controller {
 		}
 
 		$this->manager->delete($id);
-
-		$notification = $this->notificationManager->createNotification();
-		$notification->setApp('announcementcenter')
-			->setObject('announcement', $id);
-		$this->notificationManager->markProcessed($notification);
 
 		return new Response();
 	}

--- a/lib/Controller/PageController.php
+++ b/lib/Controller/PageController.php
@@ -127,6 +127,7 @@ class PageController extends Controller {
 				'subject'	=> $row['subject'],
 				'message'	=> $row['message'],
 				'groups'	=> $row['groups'],
+				'comments'	=> $row['comments'],
 			];
 		}
 
@@ -141,9 +142,10 @@ class PageController extends Controller {
 	 * @param string[] $groups,
 	 * @param bool $activities
 	 * @param bool $notifications
+	 * @param bool $comments
 	 * @return JSONResponse
 	 */
-	public function add($subject, $message, array $groups, $activities, $notifications) {
+	public function add($subject, $message, array $groups, $activities, $notifications, $comments) {
 		if (!$this->manager->checkIsAdmin()) {
 			return new JSONResponse(
 				['message' => 'Logged in user must be an admin'],
@@ -153,7 +155,7 @@ class PageController extends Controller {
 
 		$timeStamp = time();
 		try {
-			$announcement = $this->manager->announce($subject, $message, $this->userSession->getUser()->getUID(), $timeStamp, $groups);
+			$announcement = $this->manager->announce($subject, $message, $this->userSession->getUser()->getUID(), $timeStamp, $groups, $comments);
 		} catch (\InvalidArgumentException $e) {
 			return new JSONResponse(
 				['error' => (string)$this->l->t('The subject is too long or empty')],
@@ -205,6 +207,7 @@ class PageController extends Controller {
 			'isAdmin'	=> $this->manager->checkIsAdmin(),
 			'createActivities' => $this->config->getAppValue('announcementcenter', 'create_activities', 'yes') === 'yes',
 			'createNotifications' => $this->config->getAppValue('announcementcenter', 'create_notifications', 'yes') === 'yes',
+			'allowComments' => $this->config->getAppValue('announcementcenter', 'allow_comments', 'yes') === 'yes',
 		]);
 	}
 

--- a/lib/Manager.php
+++ b/lib/Manager.php
@@ -80,10 +80,11 @@ class Manager {
 	 * @param string $user
 	 * @param int $time
 	 * @param string[] $groups
+	 * @param bool $comments
 	 * @return array
 	 * @throws \InvalidArgumentException when the subject is empty or invalid
 	 */
-	public function announce($subject, $message, $user, $time, array $groups) {
+	public function announce($subject, $message, $user, $time, array $groups, $comments) {
 		$subject = trim($subject);
 		$message = trim($message);
 		if (isset($subject[512])) {
@@ -101,6 +102,7 @@ class Manager {
 				'announcement_user' => $queryBuilder->createNamedParameter($user),
 				'announcement_subject' => $queryBuilder->createNamedParameter($subject),
 				'announcement_message' => $queryBuilder->createNamedParameter($message),
+				'allow_comments' => $queryBuilder->createNamedParameter((int) $comments),
 			]);
 		$queryBuilder->execute();
 
@@ -219,6 +221,7 @@ class Manager {
 			'subject'	=> ($parseStrings) ? $this->parseSubject($row['announcement_subject']) : $row['announcement_subject'],
 			'message'	=> ($parseStrings) ? $this->parseMessage($row['announcement_message']) : $row['announcement_message'],
 			'groups'	=> $groups,
+			'comments'	=> $row['allow_comments'] === '1',
 		];
 	}
 
@@ -268,6 +271,7 @@ class Manager {
 				'subject'	=> ($parseStrings) ? $this->parseSubject($row['announcement_subject']) : $row['announcement_subject'],
 				'message'	=> ($parseStrings) ? $this->parseMessage($row['announcement_message']) : $row['announcement_message'],
 				'groups'	=> null,
+				'comments'	=> (bool) $row['allow_comments'],
 			];
 		}
 		$result->closeCursor();

--- a/lib/Manager.php
+++ b/lib/Manager.php
@@ -221,7 +221,7 @@ class Manager {
 			'subject'	=> ($parseStrings) ? $this->parseSubject($row['announcement_subject']) : $row['announcement_subject'],
 			'message'	=> ($parseStrings) ? $this->parseMessage($row['announcement_message']) : $row['announcement_message'],
 			'groups'	=> $groups,
-			'comments'	=> (bool) $row['allow_comments'],
+			'comments'	=> $row['allow_comments'] ? 0 : false,
 		];
 	}
 
@@ -271,7 +271,7 @@ class Manager {
 				'subject'	=> ($parseStrings) ? $this->parseSubject($row['announcement_subject']) : $row['announcement_subject'],
 				'message'	=> ($parseStrings) ? $this->parseMessage($row['announcement_message']) : $row['announcement_message'],
 				'groups'	=> null,
-				'comments'	=> (bool) $row['allow_comments'],
+				'comments'	=> $row['allow_comments'] ? $this->getNumberOfComments($id) : false,
 			];
 		}
 		$result->closeCursor();
@@ -315,6 +315,14 @@ class Manager {
 		$result->closeCursor();
 
 		return $returnSingleResult ? (array) array_pop($groups) : $groups;
+	}
+
+	/**
+	 * @param int $id
+	 * @return int
+	 */
+	protected function getNumberOfComments($id) {
+		return $this->commentsManager->getNumberOfCommentsForObject('announcement', (string) $id);
 	}
 
 	/**

--- a/lib/Manager.php
+++ b/lib/Manager.php
@@ -221,7 +221,7 @@ class Manager {
 			'subject'	=> ($parseStrings) ? $this->parseSubject($row['announcement_subject']) : $row['announcement_subject'],
 			'message'	=> ($parseStrings) ? $this->parseMessage($row['announcement_message']) : $row['announcement_message'],
 			'groups'	=> $groups,
-			'comments'	=> $row['allow_comments'] === '1',
+			'comments'	=> (bool) $row['allow_comments'],
 		];
 	}
 

--- a/lib/Manager.php
+++ b/lib/Manager.php
@@ -23,6 +23,7 @@
 
 namespace OCA\AnnouncementCenter;
 
+use OCP\Comments\ICommentsManager;
 use OCP\DB\QueryBuilder\IQueryBuilder;
 use OCP\IConfig;
 use OCP\IDBConnection;
@@ -45,6 +46,9 @@ class Manager {
 	/** @var INotificationManager */
 	protected $notificationManager;
 
+	/** @var ICommentsManager */
+	protected $commentsManager;
+
 	/** @var IUserSession */
 	protected $userSession;
 
@@ -53,17 +57,20 @@ class Manager {
 	 * @param IDBConnection $connection
 	 * @param IGroupManager $groupManager
 	 * @param INotificationManager $notificationManager
+	 * @param ICommentsManager $commentsManager
 	 * @param IUserSession $userSession
 	 */
 	public function __construct(IConfig $config,
 								IDBConnection $connection,
 								IGroupManager $groupManager,
 								INotificationManager $notificationManager,
+								ICommentsManager $commentsManager,
 								IUserSession $userSession) {
 		$this->config = $config;
 		$this->connection = $connection;
 		$this->groupManager = $groupManager;
 		$this->notificationManager = $notificationManager;
+		$this->commentsManager = $commentsManager;
 		$this->userSession = $userSession;
 	}
 
@@ -137,6 +144,9 @@ class Manager {
 		$notification->setApp('announcementcenter')
 			->setObject('announcement', $id);
 		$this->notificationManager->markProcessed($notification);
+
+		// Delete comments
+		$this->commentsManager->deleteCommentsAtObject('announcement', (string) $id);
 
 		$query = $this->connection->getQueryBuilder();
 		$query->delete('announcements')

--- a/lib/Manager.php
+++ b/lib/Manager.php
@@ -27,6 +27,7 @@ use OCP\DB\QueryBuilder\IQueryBuilder;
 use OCP\IConfig;
 use OCP\IDBConnection;
 use OCP\IGroupManager;
+use OCP\Notification\IManager as INotificationManager;
 use OCP\IUser;
 use OCP\IUserSession;
 
@@ -41,6 +42,8 @@ class Manager {
 	/** @var IGroupManager */
 	protected $groupManager;
 
+	/** @var INotificationManager */
+	protected $notificationManager;
 
 	/** @var IUserSession */
 	protected $userSession;
@@ -49,12 +52,18 @@ class Manager {
 	 * @param IConfig $config
 	 * @param IDBConnection $connection
 	 * @param IGroupManager $groupManager
+	 * @param INotificationManager $notificationManager
 	 * @param IUserSession $userSession
 	 */
-	public function __construct(IConfig $config, IDBConnection $connection, IGroupManager $groupManager, IUserSession $userSession) {
+	public function __construct(IConfig $config,
+								IDBConnection $connection,
+								IGroupManager $groupManager,
+								INotificationManager $notificationManager,
+								IUserSession $userSession) {
 		$this->config = $config;
 		$this->connection = $connection;
 		$this->groupManager = $groupManager;
+		$this->notificationManager = $notificationManager;
 		$this->userSession = $userSession;
 	}
 
@@ -123,6 +132,12 @@ class Manager {
 	 * @param int $id
 	 */
 	public function delete($id) {
+		// Delete notifications
+		$notification = $this->notificationManager->createNotification();
+		$notification->setApp('announcementcenter')
+			->setObject('announcement', $id);
+		$this->notificationManager->markProcessed($notification);
+
 		$query = $this->connection->getQueryBuilder();
 		$query->delete('announcements')
 			->where($query->expr()->eq('announcement_id', $query->createNamedParameter((int) $id)));

--- a/templates/admin.php
+++ b/templates/admin.php
@@ -49,4 +49,11 @@ script('announcementcenter', 'admin');
 			   <?php if ($_['createNotifications']) print_unescaped('checked="checked"'); ?> />
 		<label for="announcementcenter_create_notifications"><?php p($l->t('Create notifications by default'));?></label><br/>
 	</p>
+
+	<p>
+		<input id="announcementcenter_allow_comments" name="allow_comments"
+			   type="checkbox" class="checkbox" value="1"
+			   <?php if ($_['allowComments']) print_unescaped('checked="checked"'); ?> />
+		<label for="announcementcenter_allow_comments"><?php p($l->t('Allow comments by default'));?></label><br/>
+	</p>
 </div>

--- a/templates/main.php
+++ b/templates/main.php
@@ -3,12 +3,28 @@
  * @var array $_
  * @var \OCP\IL10N $l
  */
-script('announcementcenter', 'script');
-style('announcementcenter', 'style');
+\OCP\Util::addScript('oc-backbone-webdav');
+script('announcementcenter', [
+	'script',
+	'commentmodel',
+	'commentcollection',
+	'commentsummarymodel',
+	'commentstabview',
+]);
+style('announcementcenter', [
+	'style',
+	'comments',
+]);
 ?>
 
 <div id="app" class="announcementcenter" data-is-admin="<?php if ($_['is_admin']) { p(1); } else p(0); ?>">
 	<div id="app-content">
+		<div id="app-sidebar" class="disappear detailsView scroll-container">
+			<div id="commentsTabView" class="tab">
+
+			</div>
+		</div>
+
 		<div id="app-content-wrapper">
 			<?php if ($_['isAdmin']) {
 				print_unescaped($this->inc('part.add'));

--- a/templates/part.add.php
+++ b/templates/part.add.php
@@ -22,27 +22,30 @@ script('settings', 'settings');
 		<br />
 	</p>
 
-	<p>
-		<input id="create_activities" name="create_activities"
-			   type="checkbox" class="checkbox" value="1"
-			<?php if ($_['createActivities']) print_unescaped('checked="checked"'); ?> />
-		<label for="create_activities"><?php p($l->t('Create activities'));?></label><br/>
-	</p>
-
-	<p>
-		<input id="create_notifications" name="create_notifications"
-			   type="checkbox" class="checkbox" value="1"
-			<?php if ($_['createNotifications']) print_unescaped('checked="checked"'); ?> />
-		<label for="create_notifications"><?php p($l->t('Create notifications'));?></label><br/>
-	</p>
-
-	<p>
-		<input id="allow_comments" name="allow_comments"
-			   type="checkbox" class="checkbox" value="1"
-			<?php if ($_['allowComments']) print_unescaped('checked="checked"'); ?> />
-		<label for="allow_comments"><?php p($l->t('Allow comments'));?></label><br/>
-	</p>
-
-	<input type="button" id="submit_announcement" value="<?php p($l->t('Announce')); ?>" name="submit" />
+	<input type="button" id="submit_announcement" class="primary" value="<?php p($l->t('Announce')); ?>" name="submit" />
+	<input type="button" id="announcement_options_button" value="<?php p($l->t('Advanced options')); ?>" name="options" />
 	<span id="announcement_submit_msg" class="msg"></span>
+
+	<div id="announcement_options" class="hidden">
+		<p>
+			<input id="create_activities" name="create_activities"
+				   type="checkbox" class="checkbox" value="1"
+				<?php if ($_['createActivities']) print_unescaped('checked="checked"'); ?> />
+			<label for="create_activities"><?php p($l->t('Create activities'));?></label><br/>
+		</p>
+
+		<p>
+			<input id="create_notifications" name="create_notifications"
+				   type="checkbox" class="checkbox" value="1"
+				<?php if ($_['createNotifications']) print_unescaped('checked="checked"'); ?> />
+			<label for="create_notifications"><?php p($l->t('Create notifications'));?></label><br/>
+		</p>
+
+		<p>
+			<input id="allow_comments" name="allow_comments"
+				   type="checkbox" class="checkbox" value="1"
+				<?php if ($_['allowComments']) print_unescaped('checked="checked"'); ?> />
+			<label for="allow_comments"><?php p($l->t('Allow comments'));?></label><br/>
+		</p>
+	</div>
 </form>

--- a/templates/part.add.php
+++ b/templates/part.add.php
@@ -36,6 +36,13 @@ script('settings', 'settings');
 		<label for="create_notifications"><?php p($l->t('Create notifications'));?></label><br/>
 	</p>
 
+	<p>
+		<input id="allow_comments" name="allow_comments"
+			   type="checkbox" class="checkbox" value="1"
+			<?php if ($_['allowComments']) print_unescaped('checked="checked"'); ?> />
+		<label for="allow_comments"><?php p($l->t('Allow comments'));?></label><br/>
+	</p>
+
 	<input type="button" id="submit_announcement" value="<?php p($l->t('Announce')); ?>" name="submit" />
 	<span id="announcement_submit_msg" class="msg"></span>
 </form>

--- a/tests/Controller/PageControllerTest.php
+++ b/tests/Controller/PageControllerTest.php
@@ -31,10 +31,8 @@ use OCP\IConfig;
 use OCP\IGroupManager;
 use OCP\IL10N;
 use OCP\IRequest;
-use OCP\IURLGenerator;
 use OCP\IUserManager;
 use OCP\IUserSession;
-use OCP\Notification\IManager as INotificationManager;
 
 /**
  * Class PageController
@@ -51,8 +49,6 @@ class PageControllerTest extends TestCase {
 	protected $userManager;
 	/** @var IJobList|\PHPUnit_Framework_MockObject_MockObject */
 	protected $jobList;
-	/** @var INotificationManager|\PHPUnit_Framework_MockObject_MockObject */
-	protected $notificationManager;
 	/** @var IL10N|\PHPUnit_Framework_MockObject_MockObject */
 	protected $l;
 	/** @var Manager|\PHPUnit_Framework_MockObject_MockObject */
@@ -72,9 +68,6 @@ class PageControllerTest extends TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 		$this->userManager = $this->getMockBuilder('OCP\IUserManager')
-			->disableOriginalConstructor()
-			->getMock();
-		$this->notificationManager = $this->getMockBuilder('OCP\Notification\IManager')
 			->disableOriginalConstructor()
 			->getMock();
 		$this->l = $this->getMockBuilder('OCP\IL10N')
@@ -108,7 +101,6 @@ class PageControllerTest extends TestCase {
 				$this->groupManager,
 				$this->userManager,
 				$this->jobList,
-				$this->notificationManager,
 				$this->l,
 				$this->manager,
 				$this->config,
@@ -123,7 +115,6 @@ class PageControllerTest extends TestCase {
 					$this->groupManager,
 					$this->userManager,
 					$this->jobList,
-					$this->notificationManager,
 					$this->l,
 					$this->manager,
 					$this->config,
@@ -229,32 +220,10 @@ class PageControllerTest extends TestCase {
 			->willReturn($isAdmin);
 
 		if ($isAdmin) {
-			$notification = $this->getMockBuilder('OCP\Notification\INotification')
-				->disableOriginalConstructor()
-				->getMock();
-			$notification->expects($this->once())
-				->method('setApp')
-				->with('announcementcenter')
-				->willReturnSelf();
-			$notification->expects($this->once())
-				->method('setObject')
-				->with('announcement', $id)
-				->willReturnSelf();
-
-			$this->notificationManager->expects($this->once())
-				->method('createNotification')
-				->willReturn($notification);
-			$this->notificationManager->expects($this->once())
-				->method('markProcessed')
-				->with($notification);
-
 			$this->manager->expects($this->once())
 				->method('delete')
 				->with($id);
 		} else {
-			$this->notificationManager->expects($this->never())
-				->method('markProcessed');
-
 			$this->manager->expects($this->never())
 				->method('delete');
 		}

--- a/tests/Controller/PageControllerTest.php
+++ b/tests/Controller/PageControllerTest.php
@@ -146,32 +146,32 @@ class PageControllerTest extends TestCase {
 			[
 				1,
 				[
-					['id' => 1337, 'author' => 'author1', 'subject' => 'Subject #1', 'message' => 'Message #1', 'time' => 1440672792, 'groups' => ['gid1']],
+					['id' => 1337, 'author' => 'author1', 'subject' => 'Subject #1', 'message' => 'Message #1', 'time' => 1440672792, 'groups' => ['gid1'], 'comments' => false],
 				], [],
 				[
-					['id' => 1337, 'author' => 'author1', 'author_id' => 'author1', 'subject' => 'Subject #1', 'message' => 'Message #1', 'time' => 1440672792, 'groups' => ['gid1']],
+					['id' => 1337, 'author' => 'author1', 'author_id' => 'author1', 'subject' => 'Subject #1', 'message' => 'Message #1', 'time' => 1440672792, 'groups' => ['gid1'], 'comments' => false],
 				],
 			],
 			[
 				1,
 				[
-					['id' => 23, 'author' => 'author1', 'subject' => 'Subject #1', 'message' => 'Message #1', 'time' => 1440672792, 'groups' => ['gid1']],
+					['id' => 23, 'author' => 'author1', 'subject' => 'Subject #1', 'message' => 'Message #1', 'time' => 1440672792, 'groups' => ['gid1'], 'comments' => false],
 				],
 				[
 					['author1', $this->getUserMock('author1', 'Author One')],
 				],
 				[
-					['id' => 23, 'author' => 'Author One', 'author_id' => 'author1', 'subject' => 'Subject #1', 'message' => 'Message #1', 'time' => 1440672792, 'groups' => ['gid1']],
+					['id' => 23, 'author' => 'Author One', 'author_id' => 'author1', 'subject' => 'Subject #1', 'message' => 'Message #1', 'time' => 1440672792, 'groups' => ['gid1'], 'comments' => false],
 				],
 			],
 			[
 				1,
 				[
-					['id' => 42, 'author' => 'author1', 'subject' => "Subject &lt;html&gt;#1&lt;/html&gt;", 'message' => "Message<br />&lt;html&gt;#1&lt;/html&gt;", 'time' => 1440672792, 'groups' => null],
+					['id' => 42, 'author' => 'author1', 'subject' => "Subject &lt;html&gt;#1&lt;/html&gt;", 'message' => "Message<br />&lt;html&gt;#1&lt;/html&gt;", 'time' => 1440672792, 'groups' => null, 'comments' => true],
 				],
 				[],
 				[
-					['id' => 42, 'author' => 'author1', 'author_id' => 'author1', 'subject' => 'Subject &lt;html&gt;#1&lt;/html&gt;', 'message' => 'Message<br />&lt;html&gt;#1&lt;/html&gt;', 'time' => 1440672792, 'groups' => null],
+					['id' => 42, 'author' => 'author1', 'author_id' => 'author1', 'subject' => 'Subject &lt;html&gt;#1&lt;/html&gt;', 'message' => 'Message<br />&lt;html&gt;#1&lt;/html&gt;', 'time' => 1440672792, 'groups' => null, 'comments' => true],
 				],
 			],
 		];
@@ -264,7 +264,7 @@ class PageControllerTest extends TestCase {
 		$controller->expects($this->never())
 			->method('createPublicity');
 
-		$response = $controller->add($subject, '', [], true, true);
+		$response = $controller->add($subject, '', [], true, true, true);
 
 		$this->assertInstanceOf('OCP\AppFramework\Http\JSONResponse', $response);
 		$this->assertSame($expectedData, $response->getData());
@@ -284,7 +284,7 @@ class PageControllerTest extends TestCase {
 		$controller->expects($this->never())
 			->method('createPublicity');
 
-		$response = $controller->add('subject', '', [], true, true);
+		$response = $controller->add('subject', '', [], true, true, true);
 
 		$this->assertInstanceOf('OCP\AppFramework\Http\JSONResponse', $response);
 		$this->assertSame(Http::STATUS_FORBIDDEN, $response->getStatus());
@@ -292,10 +292,11 @@ class PageControllerTest extends TestCase {
 
 	public function dataAdd() {
 		return [
-			['subject1', 'message1', ['gid1'], true, true],
-			['subject2', 'message2', ['gid2'], true, false],
-			['subject3', 'message3', ['gid3'], false, true],
-			['subject4', 'message4', ['gid4'], false, false],
+			['subject1', 'message1', ['gid1'], true, true, false],
+			['subject2', 'message2', ['gid2'], true, false, false],
+			['subject3', 'message3', ['gid3'], false, true, false],
+			['subject4', 'message4', ['gid4'], false, false, false],
+			['subject4', 'message4', ['gid4'], false, false, true],
 		];
 	}
 
@@ -307,8 +308,9 @@ class PageControllerTest extends TestCase {
 	 * @param array $groups
 	 * @param bool $activities
 	 * @param bool $notifications
+	 * @param bool $comments
 	 */
-	public function testAdd($subject, $message, array $groups, $activities, $notifications) {
+	public function testAdd($subject, $message, array $groups, $activities, $notifications, $comments) {
 		$this->manager->expects($this->once())
 			->method('checkIsAdmin')
 			->willReturn(true);
@@ -318,13 +320,14 @@ class PageControllerTest extends TestCase {
 
 		$this->manager->expects($this->once())
 			->method('announce')
-			->with($subject, $message, 'author', $this->anything(), $groups)
+			->with($subject, $message, 'author', $this->anything(), $groups, $comments)
 			->willReturn([
 				'author' => 'author',
 				'subject' => $subject,
 				'message' => $message,
 				'time' => time(),
 				'id' => 10,
+				'comments' => $comments,
 			]);
 		$this->userManager->expects($this->once())
 			->method('get')
@@ -340,7 +343,7 @@ class PageControllerTest extends TestCase {
 
 		$controller = $this->getController();
 
-		$response = $controller->add($subject, $message, $groups, $activities, $notifications);
+		$response = $controller->add($subject, $message, $groups, $activities, $notifications, $comments);
 
 		$this->assertInstanceOf('OCP\AppFramework\Http\JSONResponse', $response);
 		$data = $response->getData();
@@ -353,13 +356,15 @@ class PageControllerTest extends TestCase {
 			'subject' => $subject,
 			'message' => $message,
 			'id' => 10,
+			'comments' => $comments,
 		], $data);
 	}
 
 	public function dataIndex() {
 		return [
-			[true, 'yes', true, 'no', false],
-			[false, 'no', false, 'yes', true],
+			[true, 'yes', true, 'no', false, 'no', false],
+			[false, 'no', false, 'yes', true, 'yes', true],
+			[false, 'no', false, 'no', false, 'yes', true],
 		];
 	}
 
@@ -370,16 +375,19 @@ class PageControllerTest extends TestCase {
 	 * @param bool $createActivities
 	 * @param string $createNotificationsConfig
 	 * @param bool $createNotifications
+	 * @param string $allowCommentsConfig
+	 * @param bool $allowComments
 	 */
-	public function testIndex($isAdmin, $createActivitiesConfig, $createActivities, $createNotificationsConfig, $createNotifications) {
+	public function testIndex($isAdmin, $createActivitiesConfig, $createActivities, $createNotificationsConfig, $createNotifications, $allowCommentsConfig, $allowComments) {
 		$this->manager->expects($this->once())
 			->method('checkIsAdmin')
 			->willReturn($isAdmin);
-		$this->config->expects($this->exactly(2))
+		$this->config->expects($this->exactly(3))
 			->method('getAppValue')
 			->willReturnMap([
 				['announcementcenter', 'create_activities', 'yes', $createActivitiesConfig],
 				['announcementcenter', 'create_notifications', 'yes', $createNotificationsConfig],
+				['announcementcenter', 'allow_comments', 'yes', $allowCommentsConfig],
 			]);
 
 		$controller = $this->getController();
@@ -391,6 +399,7 @@ class PageControllerTest extends TestCase {
 				'isAdmin' => $isAdmin,
 				'createActivities' => $createActivities,
 				'createNotifications' => $createNotifications,
+				'allowComments' => $allowComments,
 			],
 			$response->getParams()
 		);

--- a/tests/ManagerTest.php
+++ b/tests/ManagerTest.php
@@ -108,7 +108,7 @@ class ManagerTest extends TestCase {
 	 * @expectedCode 2
 	 */
 	public function testAnnounceNoSubject() {
-		$this->manager->announce('', '', '', 0, []);
+		$this->manager->announce('', '', '', 0, [], false);
 	}
 
 	/**
@@ -117,7 +117,7 @@ class ManagerTest extends TestCase {
 	 * @expectedCode 1
 	 */
 	public function testAnnounceSubjectTooLong() {
-		$this->manager->announce(str_repeat('a', 513), '', '', 0, []);
+		$this->manager->announce(str_repeat('a', 513), '', '', 0, [], false);
 	}
 
 	protected function getUserMock($uid) {
@@ -182,8 +182,8 @@ class ManagerTest extends TestCase {
 
 		$this->assertEquals([], $this->manager->getAnnouncements());
 
-		$announcement = $this->manager->announce($subject, $message, $author, $time, []);
-		$announcement2 = $this->manager->announce($subject, $message, $author, $time + 2, ['gid1', 'gid2']);
+		$announcement = $this->manager->announce($subject, $message, $author, $time, [], false);
+		$announcement2 = $this->manager->announce($subject, $message, $author, $time + 2, ['gid1', 'gid2'], true);
 		if ($noGroupsSet) {
 			$announcement['groups'] = null;
 			$announcement2['groups'] = null;
@@ -195,6 +195,7 @@ class ManagerTest extends TestCase {
 		$this->assertSame('message<br />&lt;html&gt;', $announcement['message']);
 		$this->assertSame('author', $announcement['author']);
 		$this->assertSame($time, $announcement['time']);
+		$this->assertSame(false, $announcement['comments']);
 
 		$this->assertEquals($announcement, $this->manager->getAnnouncement($announcement['id']));
 		if ($canAccessBoth) {
@@ -210,6 +211,7 @@ class ManagerTest extends TestCase {
 				array_merge($announcement2, ['groups' => ['gid1', 'gid2']]),
 				$this->manager->getAnnouncement($announcement2['id'], true, true)
 			);
+			$this->assertSame(true, $announcement2['comments']);
 		}
 
 		$this->assertEquals($announcement, $this->manager->getAnnouncement($announcement['id']));
@@ -260,7 +262,7 @@ class ManagerTest extends TestCase {
 				['gid2', true],
 			]);
 
-		$announcement = $this->manager->announce($subject, $message, $author, $time, ['gid0', 'gid1', 'gid2']);
+		$announcement = $this->manager->announce($subject, $message, $author, $time, ['gid0', 'gid1', 'gid2'], true);
 		$this->assertEquals(['gid1', 'gid2'], $this->manager->getGroups($announcement['id']));
 		$this->assertDeleteMetaData($announcement['id']);
 		$this->manager->delete($announcement['id']);
@@ -279,7 +281,7 @@ class ManagerTest extends TestCase {
 				['gid0', false],
 			]);
 
-		$announcement = $this->manager->announce($subject, $message, $author, $time, ['gid0']);
+		$announcement = $this->manager->announce($subject, $message, $author, $time, ['gid0'], true);
 		$this->assertEquals(['everyone'], $this->manager->getGroups($announcement['id']));
 		$this->assertDeleteMetaData($announcement['id']);
 		$this->manager->delete($announcement['id']);

--- a/tests/ManagerTest.php
+++ b/tests/ManagerTest.php
@@ -211,7 +211,7 @@ class ManagerTest extends TestCase {
 				array_merge($announcement2, ['groups' => ['gid1', 'gid2']]),
 				$this->manager->getAnnouncement($announcement2['id'], true, true)
 			);
-			$this->assertSame(true, $announcement2['comments']);
+			$this->assertSame(0, $announcement2['comments']);
 		}
 
 		$this->assertEquals($announcement, $this->manager->getAnnouncement($announcement['id']));


### PR DESCRIPTION
Fix #3 

- [x] Delete comments when deleting an announcement
- [x] Allow to disable comments for announcements
- [x] Prevent comments on deleted/non-existing announcements
- [x] Comments UI update from https://github.com/nextcloud/server/pull/714
- [x] Hide posting options in a dropdown
- [x] Add comment count
- [x] Multi line comments: https://github.com/nextcloud/server/issues/942 => https://github.com/nextcloud/announcementcenter/issues/17
- [x] Unread indicator => https://github.com/nextcloud/announcementcenter/issues/17
