### PR TITLE
Add support for databases with ONLY_FULL_GROUP_BY

### DIFF
--- a/lib/Manager.php
+++ b/lib/Manager.php
@@ -247,10 +247,10 @@ class Manager {
 	 */
 	public function getAnnouncements($limit = 15, $offset = 0, $parseStrings = true) {
 		$query = $this->connection->getQueryBuilder();
-		$query->select('a.*')
+		$query->select('a.announcement_id', 'a.announcement_time', 'a.announcement_user', 'a.announcement_subject', 'a.announcement_message', 'a.allow_comments')
 			->from('announcements', 'a')
 			->orderBy('a.announcement_time', 'DESC')
-			->groupBy('a.announcement_id')
+			->groupBy('a.announcement_id', 'a.announcement_time', 'a.announcement_user', 'a.announcement_subject', 'a.announcement_message', 'a.allow_comments')
 			->setMaxResults($limit);
 
 		$user = $this->userSession->getUser();


### PR DESCRIPTION
For MySQL databases that have enabled the [ONLY_FULL_GROUP_BY](https://dev.mysql.com/doc/refman/5.7/en/sql-mode.html#sqlmode_only_full_group_by) mode it's not possible to select any column that is not part of the GROUP BY block. Therefore I changed the parameters for the select
and the groupBy methods to be identical.