### PR TITLE
Include announcement title in emails

### DIFF
--- a/lib/BackgroundJob.php
+++ b/lib/BackgroundJob.php
@@ -100,7 +100,7 @@ class BackgroundJob extends QueuedJob {
 			->setType('announcementcenter')
 			->setAuthor($authorId)
 			->setTimestamp($timeStamp)
-			->setSubject('announcementsubject', [$authorId])
+			->setSubject('announcementsubject', ['author' => $authorId, 'announcement' => $id])
 			->setMessage('announcementmessage')
 			->setObject('announcement', $id);
 

--- a/tests/BackgroundJobTest.php
+++ b/tests/BackgroundJobTest.php
@@ -207,7 +207,7 @@ class BackgroundJobTest extends TestCase {
 			->willReturnSelf();
 		$event->expects($this->once())
 			->method('setSubject')
-			->with('announcementsubject', ['author'])
+			->with('announcementsubject', ['author' => 'author', 'announcement' => 10])
 			->willReturnSelf();
 		$event->expects($this->once())
 			->method('setMessage')


### PR DESCRIPTION
### Before
> **Heilbronner Falken** posted an announcement

### After
> **Heilbronner Falken** announced [fefe](https://localhost/index.php/apps/announcementcenter/?announcement=2)

The reason is, that the object columns are not available on emails (yet)