### PR TITLE
[stable14] Include announcement title in emails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,15 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## 3.3.1 – 2018-10-11
+### Fixed
+- Add the announcement subject to the activity emails
+  [#118](https://github.com/nextcloud/announcementcenter/pull/118)
+
+## 3.3.0 – 2018-08-06
+### Fixed
+- Compatibility for Nextcloud 14
+
 ## 3.2.1 – 2018-02-12
 ### Fixed
 - Fix layout of announcements

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -13,7 +13,7 @@
 👪 Group permissions
 
 🔔 Notifications (Requires the notifications app to be enabled)]]></description>
-	<version>3.3.0</version>
+	<version>3.3.1</version>
 	<licence>agpl</licence>
 	<author>Joas Schilling</author>
 	<namespace>AnnouncementCenter</namespace>

--- a/lib/BackgroundJob.php
+++ b/lib/BackgroundJob.php
@@ -100,7 +100,7 @@ class BackgroundJob extends QueuedJob {
 			->setType('announcementcenter')
 			->setAuthor($authorId)
 			->setTimestamp($timeStamp)
-			->setSubject('announcementsubject', [$authorId])
+			->setSubject('announcementsubject', ['author' => $authorId, 'announcement' => $id])
 			->setMessage('announcementmessage')
 			->setObject('announcement', $id);
 

--- a/tests/BackgroundJobTest.php
+++ b/tests/BackgroundJobTest.php
@@ -207,7 +207,7 @@ class BackgroundJobTest extends TestCase {
 			->willReturnSelf();
 		$event->expects($this->once())
 			->method('setSubject')
-			->with('announcementsubject', ['author'])
+			->with('announcementsubject', ['author' => 'author', 'announcement' => 10])
 			->willReturnSelf();
 		$event->expects($this->once())
 			->method('setMessage')


### PR DESCRIPTION
Backport #117 

### Before
> **Heilbronner Falken** posted an announcement

### After
> **Heilbronner Falken** announced [fefe](https://localhost/index.php/apps/announcementcenter/?announcement=2)

The reason is, that the object columns are not available on emails (yet: https://github.com/nextcloud/activity/pull/299)