### PR TITLE
fix padding applied to navigation

### DIFF
--- a/css/style.scss
+++ b/css/style.scss
@@ -73,7 +73,7 @@
 	border-left: 1px solid var(--color-border-dark);
 }
 
-ul, ol {
+.section > ul, ol {
 	padding-inline-start: 40px;
 }
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/22591354/59600504-9c03cb80-9101-11e9-9a11-490976c49f25.png)

this change makes sure the padding on `ul` elements isn't applied to the navigation as in the screenshot (from NC 16)