### PR TITLE
allow more html tags and remove control character

### DIFF
--- a/js/script.js
+++ b/js/script.js
@@ -199,6 +199,7 @@
 
 		markdownToHtml: function (message) {
 			message = message.replace(/<br \/>/g, "\n").replace(/&gt;/g, '>');
+			message = message.replace(/&lt;/g, '<');
 			var renderer = new window.marked.Renderer();
 			renderer.link = function (href, title, text) {
 				try {
@@ -215,7 +216,7 @@
 				if (title) {
 					out += ' title="' + title + '"';
 				}
-				out += '>' + text + ' ↗</a>';
+				out += '>' + text + ' </a>';
 				return out;
 			};
 
@@ -244,9 +245,12 @@
 					SAFE_FOR_JQUERY: true,
 					ALLOWED_TAGS: [
 						'a',
+						'h3',
+						'h4',
 						'blockquote',
 						'br',
 						'code',
+						'pre',
 						'del',
 						'em',
 						'i',


### PR DESCRIPTION
To make code blocks work, the `<pre>` html needs to be allowed. Otherwise multiple line breaks and spaces are removed. 
In addition h3 and h4 have been enabled, to allow separation of the announcement into different topics.

These changes helped me create a bit cleaner announcements.

P.S. this is my very first pull request ever. Please bear with me, if I made mistakes.