### PR TITLE
Add a close button to the comment side-bar

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -31,7 +31,7 @@
 	<screenshot>https://github.com/nextcloud/announcementcenter/raw/master/docs/AnnouncementCenterFrontpage.png</screenshot>
 
 	<dependencies>
-		<nextcloud min-version="20" max-version="20" />
+		<nextcloud min-version="19" max-version="20" />
 	</dependencies>
 
 	<repair-steps>

--- a/css/style.scss
+++ b/css/style.scss
@@ -100,3 +100,17 @@
 	cursor: pointer;
 	display: inline-block;
 }
+
+#commentsTabView_header > p {
+	margin: 10px;
+	font-size: 22px;
+	font-weight: bold;
+	color: var(--color-text-light);
+	display: inline-block;
+}
+
+#commentsTabView_close_button {
+	margin: 5px;
+	position: absolute;
+	right: 0;
+}

--- a/js/script.js
+++ b/js/script.js
@@ -44,6 +44,9 @@
 			this.loadAnnouncements();
 
 			var self = this;
+			$('#commentsTabView_close_button').on('click', function () {
+				self.commentsTabView.setObjectId(0);
+			});
 			$('#announcement_options_button').on('click', function() {
 				$('#announcement_options').toggleClass('hidden');
 			});

--- a/templates/main.php
+++ b/templates/main.php
@@ -35,5 +35,9 @@ style('announcementcenter', [
 </div>
 
 <div id="app-sidebar" class="disappear detailsView scroll-container">
+	<div id="commentsTabView_header">
+		<p>Comments</p>
+		<input type="button" id="commentsTabView_close_button" value="X" name="close" />
+	</div>
 	<div id="commentsTabView" class="tab"></div>
 </div>


### PR DESCRIPTION
In reference to #180 this adds a closing button to the announcement comment side-bar so it may be closed on smaller screens without reloading the page.