### PR TITLE
Don't open sidebar without comments being enabled

### DIFF
--- a/src/Components/Announcement.vue
+++ b/src/Components/Announcement.vue
@@ -243,7 +243,9 @@ export default {
 		},
 		onClickFoldedMessage() {
 			this.isMessageFolded = false
-			this.$emit('click', this.id)
+			if (this.comments !== false) {
+				this.$emit('click', this.id)
+			}
 		},
 		async onRemoveNotifications() {
 			try {


### PR DESCRIPTION
### Steps

1. Post an announcement with disabled comments
2. Refresh the page so the announcement is shortened
3. Click on it

### Before

Message expands
And sidebar opens showing an error
![Bildschirmfoto von 2021-06-23 16-03-59](https://user-images.githubusercontent.com/213943/123110758-aa95c380-d43c-11eb-923d-ccfa52f7c0f2.png)

### After

Message expands
