### PR TITLE
Fixed the case when multiple announcements are added for the same gro…

### DIFF
--- a/lib/BackgroundJob.php
+++ b/lib/BackgroundJob.php
@@ -127,6 +127,7 @@ class BackgroundJob extends QueuedJob {
 		if (\in_array('everyone', $groups, true)) {
 			$this->createPublicityEveryone($announcement->getUser(), $event, $notification, $publicity);
 		} else {
+			$this->notifiedUsers = [];
 			$this->createPublicityGroups($announcement->getUser(), $event, $notification, $groups, $publicity);
 		}
 	}


### PR DESCRIPTION
Issue detailed here https://github.com/nextcloud/announcementcenter/issues/184#issuecomment-924796637

Steps:
- Create "announcement1" which should be notified to the users in Group1.
- Immediately create "announcement2" which should be notified to the users in the same Group1.
- Run the cron or wait for the cron job to run the BackgroundJob and users in Group1 will only see the "announcement1"

Here the problem is the variable protected $notifiedUsers = []; from lib/BackgroundJob.php which is reused if multiple jobs are present in the oc_jobs table. 

The fix is a very small fix which is not changing the flow, just makes sure that on every call of the method $this->createPublicityGroups the $notifiedUsers is empty as it was supposed to be. 