### PR TITLE
Support to send announcements to users via email

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -17,7 +17,7 @@
 ⚡ Activities integration
 
 🔔 Notifications integration]]></description>
-	<version>6.2.0</version>
+	<version>6.3.0</version>
 	<licence>agpl</licence>
 	<author>Joas Schilling</author>
 	<namespace>AnnouncementCenter</namespace>

--- a/lib/Activity/Setting.php
+++ b/lib/Activity/Setting.php
@@ -85,7 +85,7 @@ class Setting implements ISetting {
 	 * @since 11.0.0
 	 */
 	public function canChangeMail(): bool {
-		return true;
+		return false;
 	}
 
 	/**
@@ -93,6 +93,6 @@ class Setting implements ISetting {
 	 * @since 11.0.0
 	 */
 	public function isDefaultEnabledMail(): bool {
-		return true;
+		return false;
 	}
 }

--- a/lib/BackgroundJob.php
+++ b/lib/BackgroundJob.php
@@ -172,7 +172,7 @@ class BackgroundJob extends QueuedJob {
 			}
 
 			if (strpos(trim($line), '* ') === 0) {
-				$template->addBodyListItem(trim(substr($line, strpos($line, '*') + 1)));
+				$template->addBodyListItem(trim(substr($line, strpos($line, '*') + 1)), '', '', '', false);
 			} else {
 				$template->addBodyText($line);
 			}

--- a/lib/Controller/PageController.php
+++ b/lib/Controller/PageController.php
@@ -82,6 +82,10 @@ class PageController extends Controller {
 			$this->config->getAppValue(Application::APP_ID, 'create_notifications', 'yes') === 'yes'
 		);
 		$this->initialState->provideInitialState(
+			'sendEmails',
+			$this->config->getAppValue(Application::APP_ID, 'send_emails', 'yes') === 'yes'
+		);
+		$this->initialState->provideInitialState(
 			'allowComments',
 			$this->config->getAppValue(Application::APP_ID, 'allow_comments', 'yes') === 'yes'
 		);

--- a/lib/Manager.php
+++ b/lib/Manager.php
@@ -86,6 +86,7 @@ class Manager {
 	/**
 	 * @param string $subject
 	 * @param string $message
+	 * @param string $plainMessage
 	 * @param string $user
 	 * @param int $time
 	 * @param string[] $groups
@@ -93,9 +94,10 @@ class Manager {
 	 * @return Announcement
 	 * @throws \InvalidArgumentException when the subject is empty or invalid
 	 */
-	public function announce(string $subject, string $message, string $user, int $time, array $groups, bool $comments): Announcement {
+	public function announce(string $subject, string $message, string $plainMessage, string $user, int $time, array $groups, bool $comments): Announcement {
 		$subject = trim($subject);
 		$message = trim($message);
+		$plainMessage = trim($plainMessage);
 		if (isset($subject[512])) {
 			throw new \InvalidArgumentException('Invalid subject', 1);
 		}
@@ -107,6 +109,7 @@ class Manager {
 		$announcement = new Announcement();
 		$announcement->setSubject($subject);
 		$announcement->setMessage($message);
+		$announcement->setPlainMessage($plainMessage);
 		$announcement->setUser($user);
 		$announcement->setTime($time);
 		$announcement->setAllowComments((int) $comments);

--- a/lib/Migration/Version6030Date20220505000000.php
+++ b/lib/Migration/Version6030Date20220505000000.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * @copyright Copyright (c) 2022 Jonas <jonas@freesources.org>
+ *
+ * @author Jonas <jonas@freesources.org>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\AnnouncementCenter\Migration;
+
+use Closure;
+use OCP\DB\ISchemaWrapper;
+use OCP\DB\Types;
+use OCP\Migration\IOutput;
+use OCP\Migration\SimpleMigrationStep;
+
+/**
+ * Drop the old table without a primary key
+ */
+class Version6030Date20220505000000 extends SimpleMigrationStep {
+	/**
+	 * @param IOutput $output
+	 * @param Closure $schemaClosure
+	 * @param array   $options
+	 *
+	 * @return ISchemaWrapper|null
+	 */
+	public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper {
+		/** @var ISchemaWrapper $schema */
+		$schema = $schemaClosure();
+
+		$table = $schema->getTable('announcements');
+		if (!$table->hasColumn('announcement_plain_message')) {
+			$table->addColumn('announcement_plain_message', Types::TEXT, [
+				'notnull' => false,
+			]);
+		}
+		return $schema;
+	}
+}

--- a/lib/Model/Announcement.php
+++ b/lib/Model/Announcement.php
@@ -34,6 +34,8 @@ use OCP\AppFramework\Db\Entity;
  * @method string getSubject()
  * @method void setMessage(string $message)
  * @method string getMessage()
+ * @method void setPlainMessage(string $plainMessage)
+ * @method string getPlainMessage()
  * @method void setAllowComments(int $allowComments)
  * @method int getAllowComments()
  */
@@ -51,6 +53,9 @@ class Announcement extends Entity {
 	/** @var string */
 	protected $message;
 
+	/** @var string */
+	protected $plainMessage;
+
 	/** @var int */
 	protected $allowComments;
 
@@ -59,6 +64,7 @@ class Announcement extends Entity {
 		$this->addType('user', 'string');
 		$this->addType('subject', 'string');
 		$this->addType('message', 'string');
+		$this->addType('plainMessage', 'string');
 		$this->addType('allowComments', 'int');
 	}
 

--- a/lib/Settings/Admin.php
+++ b/lib/Settings/Admin.php
@@ -48,6 +48,7 @@ class Admin implements ISettings {
 			'adminGroups' => $adminGroups,
 			'createActivities' => $this->config->getAppValue('announcementcenter', 'create_activities', 'yes') === 'yes',
 			'createNotifications' => $this->config->getAppValue('announcementcenter', 'create_notifications', 'yes') === 'yes',
+			'sendEmails' => $this->config->getAppValue('announcementcenter', 'send_emails', 'yes') === 'yes',
 			'allowComments' => $this->config->getAppValue('announcementcenter', 'allow_comments', 'yes') === 'yes',
 		], 'blank');
 	}

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
 	"requires": true,
 	"packages": {
 		"": {
+			"name": "announcementcenter",
 			"version": "6.1.1",
 			"license": "agpl",
 			"dependencies": {
@@ -19,6 +20,8 @@
 				"@nextcloud/vue": "^5.3.1",
 				"@nextcloud/vue-dashboard": "^2.0.1",
 				"debounce": "^1.2.1",
+				"remark": "^14.0.2",
+				"strip-markdown": "^5.0.0",
 				"vue": "^2.6.14",
 				"vuex": "^3.6.2"
 			},
@@ -3312,6 +3315,14 @@
 				"@types/node": "*"
 			}
 		},
+		"node_modules/@types/debug": {
+			"version": "4.1.7",
+			"resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.7.tgz",
+			"integrity": "sha512-9AonUzyTjXXhEOa0DnqpzZi6VHlqKMswga9EXjpXnnqxwLtdvPPtlO8evrI5D9S6asFRCQ6v+wpiUKbw+vKqyg==",
+			"dependencies": {
+				"@types/ms": "*"
+			}
+		},
 		"node_modules/@types/eslint": {
 			"version": "7.28.2",
 			"resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-7.28.2.tgz",
@@ -3409,6 +3420,11 @@
 			"dev": true,
 			"peer": true
 		},
+		"node_modules/@types/ms": {
+			"version": "0.7.31",
+			"resolved": "https://registry.npmjs.org/@types/ms/-/ms-0.7.31.tgz",
+			"integrity": "sha512-iiUgKzV9AuaEkZqkOLDIvlQiL6ltuZd9tGcW3gwpnX8JbuiuhFlEGmmFXEXkN50Cvq7Os88IY2v0dkDqXYWVgA=="
+		},
 		"node_modules/@types/node": {
 			"version": "14.0.26",
 			"license": "MIT"
@@ -3487,8 +3503,9 @@
 			}
 		},
 		"node_modules/@types/unist": {
-			"version": "2.0.3",
-			"license": "MIT"
+			"version": "2.0.6",
+			"resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.6.tgz",
+			"integrity": "sha512-PBjIUxZHOuj0R15/xuwJYjFi+KZdNFrehocChv4g5hu6aFroHue8m0lBP0POdK2nKzbw0cgV1mws8+V/JAcEkQ=="
 		},
 		"node_modules/@types/ws": {
 			"version": "8.2.2",
@@ -5579,6 +5596,27 @@
 				"node": ">=0.10.0"
 			}
 		},
+		"node_modules/decode-named-character-reference": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/decode-named-character-reference/-/decode-named-character-reference-1.0.1.tgz",
+			"integrity": "sha512-YV/0HQHreRwKb7uBopyIkLG17jG6Sv2qUchk9qSoVJ2f+flwRsPNBO0hAnjt6mTNYUT+vw9Gy2ihXg4sUWPi2w==",
+			"dependencies": {
+				"character-entities": "^2.0.0"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/wooorm"
+			}
+		},
+		"node_modules/decode-named-character-reference/node_modules/character-entities": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/character-entities/-/character-entities-2.0.1.tgz",
+			"integrity": "sha512-OzmutCf2Kmc+6DrFrrPS8/tDh2+DpnrfzdICHWhcVC9eOd0N1PXmQEE1a8iM4IziIAG+8tmTq3K+oo0ubH6RRQ==",
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/wooorm"
+			}
+		},
 		"node_modules/deep-equal": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.1.1.tgz",
@@ -5690,6 +5728,14 @@
 				"node": ">= 0.6"
 			}
 		},
+		"node_modules/dequal": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.2.tgz",
+			"integrity": "sha512-q9K8BlJVxK7hQYqa6XISGmBZbtQQWVXSrRrWreHC94rMt1QL/Impruc+7p2CYSYuVIUr+YCt6hjrs1kkdJRTug==",
+			"engines": {
+				"node": ">=6"
+			}
+		},
 		"node_modules/des.js": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/des.js/-/des.js-1.0.1.tgz",
@@ -5714,6 +5760,14 @@
 			"integrity": "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==",
 			"dev": true,
 			"peer": true
+		},
+		"node_modules/diff": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/diff/-/diff-5.0.0.tgz",
+			"integrity": "sha512-/VTCrvm5Z0JGty/BWHljh+BAiw3IK+2j87NGMu8Nwc/f48WoDAC395uomO9ZD117ZOBaHmkX1oyLvkVM/aIT3w==",
+			"engines": {
+				"node": ">=0.3.1"
+			}
 		},
 		"node_modules/diffie-hellman": {
 			"version": "5.0.3",
@@ -9061,6 +9115,14 @@
 				"node": ">=0.10.0"
 			}
 		},
+		"node_modules/kleur": {
+			"version": "4.1.4",
+			"resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.4.tgz",
+			"integrity": "sha512-8QADVssbrFjivHWQU7KkMgptGTl6WAcSdlbBPY4uNF+mWr6DGcKrvY2w4FQJoXch7+fKMjj0dRrL75vk3k23OA==",
+			"engines": {
+				"node": ">=6"
+			}
+		},
 		"node_modules/klona": {
 			"version": "2.0.5",
 			"resolved": "https://registry.npmjs.org/klona/-/klona-2.0.5.tgz",
@@ -9195,6 +9257,15 @@
 			"dev": true,
 			"peer": true
 		},
+		"node_modules/longest-streak": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-3.0.1.tgz",
+			"integrity": "sha512-cHlYSUpL2s7Fb3394mYxwTYj8niTaNHUCLr0qdiCXQfSjfuA7CKofpX2uSwEfFDQ0EB7JcnMnm+GjbqqoinYYg==",
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/wooorm"
+			}
+		},
 		"node_modules/loose-envify": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
@@ -9310,6 +9381,41 @@
 				"url": "https://opencollective.com/unified"
 			}
 		},
+		"node_modules/mdast-util-from-markdown": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-1.2.0.tgz",
+			"integrity": "sha512-iZJyyvKD1+K7QX1b5jXdE7Sc5dtoTry1vzV28UZZe8Z1xVnB/czKntJ7ZAkG0tANqRnBF6p3p7GpU1y19DTf2Q==",
+			"dependencies": {
+				"@types/mdast": "^3.0.0",
+				"@types/unist": "^2.0.0",
+				"decode-named-character-reference": "^1.0.0",
+				"mdast-util-to-string": "^3.1.0",
+				"micromark": "^3.0.0",
+				"micromark-util-decode-numeric-character-reference": "^1.0.0",
+				"micromark-util-decode-string": "^1.0.0",
+				"micromark-util-normalize-identifier": "^1.0.0",
+				"micromark-util-symbol": "^1.0.0",
+				"micromark-util-types": "^1.0.0",
+				"unist-util-stringify-position": "^3.0.0",
+				"uvu": "^0.5.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/mdast-util-from-markdown/node_modules/unist-util-stringify-position": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-3.0.2.tgz",
+			"integrity": "sha512-7A6eiDCs9UtjcwZOcCpM4aPII3bAAGv13E96IkawkOAW0OhH+yRxtY0lzo8KiHpzEMfH7Q+FizUmwp8Iqy5EWg==",
+			"dependencies": {
+				"@types/unist": "^2.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
 		"node_modules/mdast-util-to-hast": {
 			"version": "10.1.1",
 			"license": "MIT",
@@ -9348,6 +9454,78 @@
 				"@types/unist": "^2.0.0",
 				"unist-util-is": "^4.0.0"
 			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/mdast-util-to-markdown": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/mdast-util-to-markdown/-/mdast-util-to-markdown-1.3.0.tgz",
+			"integrity": "sha512-6tUSs4r+KK4JGTTiQ7FfHmVOaDrLQJPmpjD6wPMlHGUVXoG9Vjc3jIeP+uyBWRf8clwB2blM+W7+KrlMYQnftA==",
+			"dependencies": {
+				"@types/mdast": "^3.0.0",
+				"@types/unist": "^2.0.0",
+				"longest-streak": "^3.0.0",
+				"mdast-util-to-string": "^3.0.0",
+				"micromark-util-decode-string": "^1.0.0",
+				"unist-util-visit": "^4.0.0",
+				"zwitch": "^2.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/mdast-util-to-markdown/node_modules/unist-util-is": {
+			"version": "5.1.1",
+			"resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-5.1.1.tgz",
+			"integrity": "sha512-F5CZ68eYzuSvJjGhCLPL3cYx45IxkqXSetCcRgUXtbcm50X2L9oOWQlfUfDdAf+6Pd27YDblBfdtmsThXmwpbQ==",
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/mdast-util-to-markdown/node_modules/unist-util-visit": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-4.1.0.tgz",
+			"integrity": "sha512-n7lyhFKJfVZ9MnKtqbsqkQEk5P1KShj0+//V7mAcoI6bpbUjh3C/OG8HVD+pBihfh6Ovl01m8dkcv9HNqYajmQ==",
+			"dependencies": {
+				"@types/unist": "^2.0.0",
+				"unist-util-is": "^5.0.0",
+				"unist-util-visit-parents": "^5.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/mdast-util-to-markdown/node_modules/unist-util-visit-parents": {
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-5.1.0.tgz",
+			"integrity": "sha512-y+QVLcY5eR/YVpqDsLf/xh9R3Q2Y4HxkZTp7ViLDU6WtJCEcPmRzW1gpdWDCDIqIlhuPDXOgttqPlykrHYDekg==",
+			"dependencies": {
+				"@types/unist": "^2.0.0",
+				"unist-util-is": "^5.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/mdast-util-to-markdown/node_modules/zwitch": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/zwitch/-/zwitch-2.0.2.tgz",
+			"integrity": "sha512-JZxotl7SxAJH0j7dN4pxsTV6ZLXoLdGME+PsjkL/DaBrVryK9kTGq06GfKrwcSOqypP+fdXGoCHE36b99fWVoA==",
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/wooorm"
+			}
+		},
+		"node_modules/mdast-util-to-string": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-3.1.0.tgz",
+			"integrity": "sha512-n4Vypz/DZgwo0iMHLQL49dJzlp7YtAJP+N07MZHpjPf/5XJuHUWstviF4Mn2jEiR/GNmtnRRqnwsXExk3igfFA==",
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/unified"
@@ -9703,6 +9881,449 @@
 				"node": ">= 0.6"
 			}
 		},
+		"node_modules/micromark": {
+			"version": "3.0.10",
+			"resolved": "https://registry.npmjs.org/micromark/-/micromark-3.0.10.tgz",
+			"integrity": "sha512-ryTDy6UUunOXy2HPjelppgJ2sNfcPz1pLlMdA6Rz9jPzhLikWXv/irpWV/I2jd68Uhmny7hHxAlAhk4+vWggpg==",
+			"funding": [
+				{
+					"type": "GitHub Sponsors",
+					"url": "https://github.com/sponsors/unifiedjs"
+				},
+				{
+					"type": "OpenCollective",
+					"url": "https://opencollective.com/unified"
+				}
+			],
+			"dependencies": {
+				"@types/debug": "^4.0.0",
+				"debug": "^4.0.0",
+				"decode-named-character-reference": "^1.0.0",
+				"micromark-core-commonmark": "^1.0.1",
+				"micromark-factory-space": "^1.0.0",
+				"micromark-util-character": "^1.0.0",
+				"micromark-util-chunked": "^1.0.0",
+				"micromark-util-combine-extensions": "^1.0.0",
+				"micromark-util-decode-numeric-character-reference": "^1.0.0",
+				"micromark-util-encode": "^1.0.0",
+				"micromark-util-normalize-identifier": "^1.0.0",
+				"micromark-util-resolve-all": "^1.0.0",
+				"micromark-util-sanitize-uri": "^1.0.0",
+				"micromark-util-subtokenize": "^1.0.0",
+				"micromark-util-symbol": "^1.0.0",
+				"micromark-util-types": "^1.0.1",
+				"uvu": "^0.5.0"
+			}
+		},
+		"node_modules/micromark-core-commonmark": {
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/micromark-core-commonmark/-/micromark-core-commonmark-1.0.6.tgz",
+			"integrity": "sha512-K+PkJTxqjFfSNkfAhp4GB+cZPfQd6dxtTXnf+RjZOV7T4EEXnvgzOcnp+eSTmpGk9d1S9sL6/lqrgSNn/s0HZA==",
+			"funding": [
+				{
+					"type": "GitHub Sponsors",
+					"url": "https://github.com/sponsors/unifiedjs"
+				},
+				{
+					"type": "OpenCollective",
+					"url": "https://opencollective.com/unified"
+				}
+			],
+			"dependencies": {
+				"decode-named-character-reference": "^1.0.0",
+				"micromark-factory-destination": "^1.0.0",
+				"micromark-factory-label": "^1.0.0",
+				"micromark-factory-space": "^1.0.0",
+				"micromark-factory-title": "^1.0.0",
+				"micromark-factory-whitespace": "^1.0.0",
+				"micromark-util-character": "^1.0.0",
+				"micromark-util-chunked": "^1.0.0",
+				"micromark-util-classify-character": "^1.0.0",
+				"micromark-util-html-tag-name": "^1.0.0",
+				"micromark-util-normalize-identifier": "^1.0.0",
+				"micromark-util-resolve-all": "^1.0.0",
+				"micromark-util-subtokenize": "^1.0.0",
+				"micromark-util-symbol": "^1.0.0",
+				"micromark-util-types": "^1.0.1",
+				"uvu": "^0.5.0"
+			}
+		},
+		"node_modules/micromark-factory-destination": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/micromark-factory-destination/-/micromark-factory-destination-1.0.0.tgz",
+			"integrity": "sha512-eUBA7Rs1/xtTVun9TmV3gjfPz2wEwgK5R5xcbIM5ZYAtvGF6JkyaDsj0agx8urXnO31tEO6Ug83iVH3tdedLnw==",
+			"funding": [
+				{
+					"type": "GitHub Sponsors",
+					"url": "https://github.com/sponsors/unifiedjs"
+				},
+				{
+					"type": "OpenCollective",
+					"url": "https://opencollective.com/unified"
+				}
+			],
+			"dependencies": {
+				"micromark-util-character": "^1.0.0",
+				"micromark-util-symbol": "^1.0.0",
+				"micromark-util-types": "^1.0.0"
+			}
+		},
+		"node_modules/micromark-factory-label": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/micromark-factory-label/-/micromark-factory-label-1.0.2.tgz",
+			"integrity": "sha512-CTIwxlOnU7dEshXDQ+dsr2n+yxpP0+fn271pu0bwDIS8uqfFcumXpj5mLn3hSC8iw2MUr6Gx8EcKng1dD7i6hg==",
+			"funding": [
+				{
+					"type": "GitHub Sponsors",
+					"url": "https://github.com/sponsors/unifiedjs"
+				},
+				{
+					"type": "OpenCollective",
+					"url": "https://opencollective.com/unified"
+				}
+			],
+			"dependencies": {
+				"micromark-util-character": "^1.0.0",
+				"micromark-util-symbol": "^1.0.0",
+				"micromark-util-types": "^1.0.0",
+				"uvu": "^0.5.0"
+			}
+		},
+		"node_modules/micromark-factory-space": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/micromark-factory-space/-/micromark-factory-space-1.0.0.tgz",
+			"integrity": "sha512-qUmqs4kj9a5yBnk3JMLyjtWYN6Mzfcx8uJfi5XAveBniDevmZasdGBba5b4QsvRcAkmvGo5ACmSUmyGiKTLZew==",
+			"funding": [
+				{
+					"type": "GitHub Sponsors",
+					"url": "https://github.com/sponsors/unifiedjs"
+				},
+				{
+					"type": "OpenCollective",
+					"url": "https://opencollective.com/unified"
+				}
+			],
+			"dependencies": {
+				"micromark-util-character": "^1.0.0",
+				"micromark-util-types": "^1.0.0"
+			}
+		},
+		"node_modules/micromark-factory-title": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/micromark-factory-title/-/micromark-factory-title-1.0.2.tgz",
+			"integrity": "sha512-zily+Nr4yFqgMGRKLpTVsNl5L4PMu485fGFDOQJQBl2NFpjGte1e86zC0da93wf97jrc4+2G2GQudFMHn3IX+A==",
+			"funding": [
+				{
+					"type": "GitHub Sponsors",
+					"url": "https://github.com/sponsors/unifiedjs"
+				},
+				{
+					"type": "OpenCollective",
+					"url": "https://opencollective.com/unified"
+				}
+			],
+			"dependencies": {
+				"micromark-factory-space": "^1.0.0",
+				"micromark-util-character": "^1.0.0",
+				"micromark-util-symbol": "^1.0.0",
+				"micromark-util-types": "^1.0.0",
+				"uvu": "^0.5.0"
+			}
+		},
+		"node_modules/micromark-factory-whitespace": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/micromark-factory-whitespace/-/micromark-factory-whitespace-1.0.0.tgz",
+			"integrity": "sha512-Qx7uEyahU1lt1RnsECBiuEbfr9INjQTGa6Err+gF3g0Tx4YEviPbqqGKNv/NrBaE7dVHdn1bVZKM/n5I/Bak7A==",
+			"funding": [
+				{
+					"type": "GitHub Sponsors",
+					"url": "https://github.com/sponsors/unifiedjs"
+				},
+				{
+					"type": "OpenCollective",
+					"url": "https://opencollective.com/unified"
+				}
+			],
+			"dependencies": {
+				"micromark-factory-space": "^1.0.0",
+				"micromark-util-character": "^1.0.0",
+				"micromark-util-symbol": "^1.0.0",
+				"micromark-util-types": "^1.0.0"
+			}
+		},
+		"node_modules/micromark-util-character": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-1.1.0.tgz",
+			"integrity": "sha512-agJ5B3unGNJ9rJvADMJ5ZiYjBRyDpzKAOk01Kpi1TKhlT1APx3XZk6eN7RtSz1erbWHC2L8T3xLZ81wdtGRZzg==",
+			"funding": [
+				{
+					"type": "GitHub Sponsors",
+					"url": "https://github.com/sponsors/unifiedjs"
+				},
+				{
+					"type": "OpenCollective",
+					"url": "https://opencollective.com/unified"
+				}
+			],
+			"dependencies": {
+				"micromark-util-symbol": "^1.0.0",
+				"micromark-util-types": "^1.0.0"
+			}
+		},
+		"node_modules/micromark-util-chunked": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/micromark-util-chunked/-/micromark-util-chunked-1.0.0.tgz",
+			"integrity": "sha512-5e8xTis5tEZKgesfbQMKRCyzvffRRUX+lK/y+DvsMFdabAicPkkZV6gO+FEWi9RfuKKoxxPwNL+dFF0SMImc1g==",
+			"funding": [
+				{
+					"type": "GitHub Sponsors",
+					"url": "https://github.com/sponsors/unifiedjs"
+				},
+				{
+					"type": "OpenCollective",
+					"url": "https://opencollective.com/unified"
+				}
+			],
+			"dependencies": {
+				"micromark-util-symbol": "^1.0.0"
+			}
+		},
+		"node_modules/micromark-util-classify-character": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/micromark-util-classify-character/-/micromark-util-classify-character-1.0.0.tgz",
+			"integrity": "sha512-F8oW2KKrQRb3vS5ud5HIqBVkCqQi224Nm55o5wYLzY/9PwHGXC01tr3d7+TqHHz6zrKQ72Okwtvm/xQm6OVNZA==",
+			"funding": [
+				{
+					"type": "GitHub Sponsors",
+					"url": "https://github.com/sponsors/unifiedjs"
+				},
+				{
+					"type": "OpenCollective",
+					"url": "https://opencollective.com/unified"
+				}
+			],
+			"dependencies": {
+				"micromark-util-character": "^1.0.0",
+				"micromark-util-symbol": "^1.0.0",
+				"micromark-util-types": "^1.0.0"
+			}
+		},
+		"node_modules/micromark-util-combine-extensions": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/micromark-util-combine-extensions/-/micromark-util-combine-extensions-1.0.0.tgz",
+			"integrity": "sha512-J8H058vFBdo/6+AsjHp2NF7AJ02SZtWaVUjsayNFeAiydTxUwViQPxN0Hf8dp4FmCQi0UUFovFsEyRSUmFH3MA==",
+			"funding": [
+				{
+					"type": "GitHub Sponsors",
+					"url": "https://github.com/sponsors/unifiedjs"
+				},
+				{
+					"type": "OpenCollective",
+					"url": "https://opencollective.com/unified"
+				}
+			],
+			"dependencies": {
+				"micromark-util-chunked": "^1.0.0",
+				"micromark-util-types": "^1.0.0"
+			}
+		},
+		"node_modules/micromark-util-decode-numeric-character-reference": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/micromark-util-decode-numeric-character-reference/-/micromark-util-decode-numeric-character-reference-1.0.0.tgz",
+			"integrity": "sha512-OzO9AI5VUtrTD7KSdagf4MWgHMtET17Ua1fIpXTpuhclCqD8egFWo85GxSGvxgkGS74bEahvtM0WP0HjvV0e4w==",
+			"funding": [
+				{
+					"type": "GitHub Sponsors",
+					"url": "https://github.com/sponsors/unifiedjs"
+				},
+				{
+					"type": "OpenCollective",
+					"url": "https://opencollective.com/unified"
+				}
+			],
+			"dependencies": {
+				"micromark-util-symbol": "^1.0.0"
+			}
+		},
+		"node_modules/micromark-util-decode-string": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/micromark-util-decode-string/-/micromark-util-decode-string-1.0.2.tgz",
+			"integrity": "sha512-DLT5Ho02qr6QWVNYbRZ3RYOSSWWFuH3tJexd3dgN1odEuPNxCngTCXJum7+ViRAd9BbdxCvMToPOD/IvVhzG6Q==",
+			"funding": [
+				{
+					"type": "GitHub Sponsors",
+					"url": "https://github.com/sponsors/unifiedjs"
+				},
+				{
+					"type": "OpenCollective",
+					"url": "https://opencollective.com/unified"
+				}
+			],
+			"dependencies": {
+				"decode-named-character-reference": "^1.0.0",
+				"micromark-util-character": "^1.0.0",
+				"micromark-util-decode-numeric-character-reference": "^1.0.0",
+				"micromark-util-symbol": "^1.0.0"
+			}
+		},
+		"node_modules/micromark-util-encode": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/micromark-util-encode/-/micromark-util-encode-1.0.1.tgz",
+			"integrity": "sha512-U2s5YdnAYexjKDel31SVMPbfi+eF8y1U4pfiRW/Y8EFVCy/vgxk/2wWTxzcqE71LHtCuCzlBDRU2a5CQ5j+mQA==",
+			"funding": [
+				{
+					"type": "GitHub Sponsors",
+					"url": "https://github.com/sponsors/unifiedjs"
+				},
+				{
+					"type": "OpenCollective",
+					"url": "https://opencollective.com/unified"
+				}
+			]
+		},
+		"node_modules/micromark-util-html-tag-name": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/micromark-util-html-tag-name/-/micromark-util-html-tag-name-1.0.0.tgz",
+			"integrity": "sha512-NenEKIshW2ZI/ERv9HtFNsrn3llSPZtY337LID/24WeLqMzeZhBEE6BQ0vS2ZBjshm5n40chKtJ3qjAbVV8S0g==",
+			"funding": [
+				{
+					"type": "GitHub Sponsors",
+					"url": "https://github.com/sponsors/unifiedjs"
+				},
+				{
+					"type": "OpenCollective",
+					"url": "https://opencollective.com/unified"
+				}
+			]
+		},
+		"node_modules/micromark-util-normalize-identifier": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/micromark-util-normalize-identifier/-/micromark-util-normalize-identifier-1.0.0.tgz",
+			"integrity": "sha512-yg+zrL14bBTFrQ7n35CmByWUTFsgst5JhA4gJYoty4Dqzj4Z4Fr/DHekSS5aLfH9bdlfnSvKAWsAgJhIbogyBg==",
+			"funding": [
+				{
+					"type": "GitHub Sponsors",
+					"url": "https://github.com/sponsors/unifiedjs"
+				},
+				{
+					"type": "OpenCollective",
+					"url": "https://opencollective.com/unified"
+				}
+			],
+			"dependencies": {
+				"micromark-util-symbol": "^1.0.0"
+			}
+		},
+		"node_modules/micromark-util-resolve-all": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/micromark-util-resolve-all/-/micromark-util-resolve-all-1.0.0.tgz",
+			"integrity": "sha512-CB/AGk98u50k42kvgaMM94wzBqozSzDDaonKU7P7jwQIuH2RU0TeBqGYJz2WY1UdihhjweivStrJ2JdkdEmcfw==",
+			"funding": [
+				{
+					"type": "GitHub Sponsors",
+					"url": "https://github.com/sponsors/unifiedjs"
+				},
+				{
+					"type": "OpenCollective",
+					"url": "https://opencollective.com/unified"
+				}
+			],
+			"dependencies": {
+				"micromark-util-types": "^1.0.0"
+			}
+		},
+		"node_modules/micromark-util-sanitize-uri": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-1.0.0.tgz",
+			"integrity": "sha512-cCxvBKlmac4rxCGx6ejlIviRaMKZc0fWm5HdCHEeDWRSkn44l6NdYVRyU+0nT1XC72EQJMZV8IPHF+jTr56lAg==",
+			"funding": [
+				{
+					"type": "GitHub Sponsors",
+					"url": "https://github.com/sponsors/unifiedjs"
+				},
+				{
+					"type": "OpenCollective",
+					"url": "https://opencollective.com/unified"
+				}
+			],
+			"dependencies": {
+				"micromark-util-character": "^1.0.0",
+				"micromark-util-encode": "^1.0.0",
+				"micromark-util-symbol": "^1.0.0"
+			}
+		},
+		"node_modules/micromark-util-subtokenize": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/micromark-util-subtokenize/-/micromark-util-subtokenize-1.0.2.tgz",
+			"integrity": "sha512-d90uqCnXp/cy4G881Ub4psE57Sf8YD0pim9QdjCRNjfas2M1u6Lbt+XZK9gnHL2XFhnozZiEdCa9CNfXSfQ6xA==",
+			"funding": [
+				{
+					"type": "GitHub Sponsors",
+					"url": "https://github.com/sponsors/unifiedjs"
+				},
+				{
+					"type": "OpenCollective",
+					"url": "https://opencollective.com/unified"
+				}
+			],
+			"dependencies": {
+				"micromark-util-chunked": "^1.0.0",
+				"micromark-util-symbol": "^1.0.0",
+				"micromark-util-types": "^1.0.0",
+				"uvu": "^0.5.0"
+			}
+		},
+		"node_modules/micromark-util-symbol": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-1.0.1.tgz",
+			"integrity": "sha512-oKDEMK2u5qqAptasDAwWDXq0tG9AssVwAx3E9bBF3t/shRIGsWIRG+cGafs2p/SnDSOecnt6hZPCE2o6lHfFmQ==",
+			"funding": [
+				{
+					"type": "GitHub Sponsors",
+					"url": "https://github.com/sponsors/unifiedjs"
+				},
+				{
+					"type": "OpenCollective",
+					"url": "https://opencollective.com/unified"
+				}
+			]
+		},
+		"node_modules/micromark-util-types": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-1.0.2.tgz",
+			"integrity": "sha512-DCfg/T8fcrhrRKTPjRrw/5LLvdGV7BHySf/1LOZx7TzWZdYRjogNtyNq885z3nNallwr3QUKARjqvHqX1/7t+w==",
+			"funding": [
+				{
+					"type": "GitHub Sponsors",
+					"url": "https://github.com/sponsors/unifiedjs"
+				},
+				{
+					"type": "OpenCollective",
+					"url": "https://opencollective.com/unified"
+				}
+			]
+		},
+		"node_modules/micromark/node_modules/debug": {
+			"version": "4.3.4",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+			"integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+			"dependencies": {
+				"ms": "2.1.2"
+			},
+			"engines": {
+				"node": ">=6.0"
+			},
+			"peerDependenciesMeta": {
+				"supports-color": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/micromark/node_modules/ms": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+			"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+		},
 		"node_modules/miller-rabin": {
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-4.0.1.tgz",
@@ -9861,6 +10482,14 @@
 			"integrity": "sha512-c6YRvhEo//6T2Jz/vVtYzqBzwvPT95JBQ+smCytzf7c50oMZRsR/a4w88aD34I+/QVSfnoAnSBFPJHItlOMJVw==",
 			"engines": {
 				"node": "*"
+			}
+		},
+		"node_modules/mri": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/mri/-/mri-1.2.0.tgz",
+			"integrity": "sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==",
+			"engines": {
+				"node": ">=4"
 			}
 		},
 		"node_modules/ms": {
@@ -11051,6 +11680,21 @@
 				"url": "https://opencollective.com/unified"
 			}
 		},
+		"node_modules/remark": {
+			"version": "14.0.2",
+			"resolved": "https://registry.npmjs.org/remark/-/remark-14.0.2.tgz",
+			"integrity": "sha512-A3ARm2V4BgiRXaUo5K0dRvJ1lbogrbXnhkJRmD0yw092/Yl0kOCZt1k9ZeElEwkZsWGsMumz6qL5MfNJH9nOBA==",
+			"dependencies": {
+				"@types/mdast": "^3.0.0",
+				"remark-parse": "^10.0.0",
+				"remark-stringify": "^10.0.0",
+				"unified": "^10.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
 		"node_modules/remark-breaks": {
 			"version": "2.0.0",
 			"license": "MIT",
@@ -11109,11 +11753,366 @@
 				"url": "https://opencollective.com/unified"
 			}
 		},
+		"node_modules/remark-parse": {
+			"version": "10.0.1",
+			"resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-10.0.1.tgz",
+			"integrity": "sha512-1fUyHr2jLsVOkhbvPRBJ5zTKZZyD6yZzYaWCS6BPBdQ8vEMBCH+9zNCDA6tET/zHCi/jLqjCWtlJZUPk+DbnFw==",
+			"dependencies": {
+				"@types/mdast": "^3.0.0",
+				"mdast-util-from-markdown": "^1.0.0",
+				"unified": "^10.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/remark-parse/node_modules/bail": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/bail/-/bail-2.0.2.tgz",
+			"integrity": "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==",
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/wooorm"
+			}
+		},
+		"node_modules/remark-parse/node_modules/is-buffer": {
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.5.tgz",
+			"integrity": "sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			],
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/remark-parse/node_modules/is-plain-obj": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.0.0.tgz",
+			"integrity": "sha512-NXRbBtUdBioI73y/HmOhogw/U5msYPC9DAtGkJXeFcFWSFZw0mCUsPxk/snTuJHzNKA8kLBK4rH97RMB1BfCXw==",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/remark-parse/node_modules/trough": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/trough/-/trough-2.1.0.tgz",
+			"integrity": "sha512-AqTiAOLcj85xS7vQ8QkAV41hPDIJ71XJB4RCUrzo/1GM2CQwhkJGaf9Hgr7BOugMRpgGUrqRg/DrBDl4H40+8g==",
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/wooorm"
+			}
+		},
+		"node_modules/remark-parse/node_modules/unified": {
+			"version": "10.1.2",
+			"resolved": "https://registry.npmjs.org/unified/-/unified-10.1.2.tgz",
+			"integrity": "sha512-pUSWAi/RAnVy1Pif2kAoeWNBa3JVrx0MId2LASj8G+7AiHWoKZNTomq6LG326T68U7/e263X6fTdcXIy7XnF7Q==",
+			"dependencies": {
+				"@types/unist": "^2.0.0",
+				"bail": "^2.0.0",
+				"extend": "^3.0.0",
+				"is-buffer": "^2.0.0",
+				"is-plain-obj": "^4.0.0",
+				"trough": "^2.0.0",
+				"vfile": "^5.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/remark-parse/node_modules/unist-util-stringify-position": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-3.0.2.tgz",
+			"integrity": "sha512-7A6eiDCs9UtjcwZOcCpM4aPII3bAAGv13E96IkawkOAW0OhH+yRxtY0lzo8KiHpzEMfH7Q+FizUmwp8Iqy5EWg==",
+			"dependencies": {
+				"@types/unist": "^2.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/remark-parse/node_modules/vfile": {
+			"version": "5.3.2",
+			"resolved": "https://registry.npmjs.org/vfile/-/vfile-5.3.2.tgz",
+			"integrity": "sha512-w0PLIugRY3Crkgw89TeMvHCzqCs/zpreR31hl4D92y6SOE07+bfJe+dK5Q2akwS+i/c801kzjoOr9gMcTe6IAA==",
+			"dependencies": {
+				"@types/unist": "^2.0.0",
+				"is-buffer": "^2.0.0",
+				"unist-util-stringify-position": "^3.0.0",
+				"vfile-message": "^3.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/remark-parse/node_modules/vfile-message": {
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-3.1.2.tgz",
+			"integrity": "sha512-QjSNP6Yxzyycd4SVOtmKKyTsSvClqBPJcd00Z0zuPj3hOIjg0rUPG6DbFGPvUKRgYyaIWLPKpuEclcuvb3H8qA==",
+			"dependencies": {
+				"@types/unist": "^2.0.0",
+				"unist-util-stringify-position": "^3.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
 		"node_modules/remark-rehype": {
 			"version": "8.0.0",
 			"license": "MIT",
 			"dependencies": {
 				"mdast-util-to-hast": "^10.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/remark-stringify": {
+			"version": "10.0.2",
+			"resolved": "https://registry.npmjs.org/remark-stringify/-/remark-stringify-10.0.2.tgz",
+			"integrity": "sha512-6wV3pvbPvHkbNnWB0wdDvVFHOe1hBRAx1Q/5g/EpH4RppAII6J8Gnwe7VbHuXaoKIF6LAg6ExTel/+kNqSQ7lw==",
+			"dependencies": {
+				"@types/mdast": "^3.0.0",
+				"mdast-util-to-markdown": "^1.0.0",
+				"unified": "^10.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/remark-stringify/node_modules/bail": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/bail/-/bail-2.0.2.tgz",
+			"integrity": "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==",
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/wooorm"
+			}
+		},
+		"node_modules/remark-stringify/node_modules/is-buffer": {
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.5.tgz",
+			"integrity": "sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			],
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/remark-stringify/node_modules/is-plain-obj": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.0.0.tgz",
+			"integrity": "sha512-NXRbBtUdBioI73y/HmOhogw/U5msYPC9DAtGkJXeFcFWSFZw0mCUsPxk/snTuJHzNKA8kLBK4rH97RMB1BfCXw==",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/remark-stringify/node_modules/trough": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/trough/-/trough-2.1.0.tgz",
+			"integrity": "sha512-AqTiAOLcj85xS7vQ8QkAV41hPDIJ71XJB4RCUrzo/1GM2CQwhkJGaf9Hgr7BOugMRpgGUrqRg/DrBDl4H40+8g==",
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/wooorm"
+			}
+		},
+		"node_modules/remark-stringify/node_modules/unified": {
+			"version": "10.1.2",
+			"resolved": "https://registry.npmjs.org/unified/-/unified-10.1.2.tgz",
+			"integrity": "sha512-pUSWAi/RAnVy1Pif2kAoeWNBa3JVrx0MId2LASj8G+7AiHWoKZNTomq6LG326T68U7/e263X6fTdcXIy7XnF7Q==",
+			"dependencies": {
+				"@types/unist": "^2.0.0",
+				"bail": "^2.0.0",
+				"extend": "^3.0.0",
+				"is-buffer": "^2.0.0",
+				"is-plain-obj": "^4.0.0",
+				"trough": "^2.0.0",
+				"vfile": "^5.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/remark-stringify/node_modules/unist-util-stringify-position": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-3.0.2.tgz",
+			"integrity": "sha512-7A6eiDCs9UtjcwZOcCpM4aPII3bAAGv13E96IkawkOAW0OhH+yRxtY0lzo8KiHpzEMfH7Q+FizUmwp8Iqy5EWg==",
+			"dependencies": {
+				"@types/unist": "^2.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/remark-stringify/node_modules/vfile": {
+			"version": "5.3.2",
+			"resolved": "https://registry.npmjs.org/vfile/-/vfile-5.3.2.tgz",
+			"integrity": "sha512-w0PLIugRY3Crkgw89TeMvHCzqCs/zpreR31hl4D92y6SOE07+bfJe+dK5Q2akwS+i/c801kzjoOr9gMcTe6IAA==",
+			"dependencies": {
+				"@types/unist": "^2.0.0",
+				"is-buffer": "^2.0.0",
+				"unist-util-stringify-position": "^3.0.0",
+				"vfile-message": "^3.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/remark-stringify/node_modules/vfile-message": {
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-3.1.2.tgz",
+			"integrity": "sha512-QjSNP6Yxzyycd4SVOtmKKyTsSvClqBPJcd00Z0zuPj3hOIjg0rUPG6DbFGPvUKRgYyaIWLPKpuEclcuvb3H8qA==",
+			"dependencies": {
+				"@types/unist": "^2.0.0",
+				"unist-util-stringify-position": "^3.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/remark/node_modules/bail": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/bail/-/bail-2.0.2.tgz",
+			"integrity": "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==",
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/wooorm"
+			}
+		},
+		"node_modules/remark/node_modules/is-buffer": {
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.5.tgz",
+			"integrity": "sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			],
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/remark/node_modules/is-plain-obj": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.0.0.tgz",
+			"integrity": "sha512-NXRbBtUdBioI73y/HmOhogw/U5msYPC9DAtGkJXeFcFWSFZw0mCUsPxk/snTuJHzNKA8kLBK4rH97RMB1BfCXw==",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/remark/node_modules/trough": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/trough/-/trough-2.1.0.tgz",
+			"integrity": "sha512-AqTiAOLcj85xS7vQ8QkAV41hPDIJ71XJB4RCUrzo/1GM2CQwhkJGaf9Hgr7BOugMRpgGUrqRg/DrBDl4H40+8g==",
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/wooorm"
+			}
+		},
+		"node_modules/remark/node_modules/unified": {
+			"version": "10.1.2",
+			"resolved": "https://registry.npmjs.org/unified/-/unified-10.1.2.tgz",
+			"integrity": "sha512-pUSWAi/RAnVy1Pif2kAoeWNBa3JVrx0MId2LASj8G+7AiHWoKZNTomq6LG326T68U7/e263X6fTdcXIy7XnF7Q==",
+			"dependencies": {
+				"@types/unist": "^2.0.0",
+				"bail": "^2.0.0",
+				"extend": "^3.0.0",
+				"is-buffer": "^2.0.0",
+				"is-plain-obj": "^4.0.0",
+				"trough": "^2.0.0",
+				"vfile": "^5.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/remark/node_modules/unist-util-stringify-position": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-3.0.2.tgz",
+			"integrity": "sha512-7A6eiDCs9UtjcwZOcCpM4aPII3bAAGv13E96IkawkOAW0OhH+yRxtY0lzo8KiHpzEMfH7Q+FizUmwp8Iqy5EWg==",
+			"dependencies": {
+				"@types/unist": "^2.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/remark/node_modules/vfile": {
+			"version": "5.3.2",
+			"resolved": "https://registry.npmjs.org/vfile/-/vfile-5.3.2.tgz",
+			"integrity": "sha512-w0PLIugRY3Crkgw89TeMvHCzqCs/zpreR31hl4D92y6SOE07+bfJe+dK5Q2akwS+i/c801kzjoOr9gMcTe6IAA==",
+			"dependencies": {
+				"@types/unist": "^2.0.0",
+				"is-buffer": "^2.0.0",
+				"unist-util-stringify-position": "^3.0.0",
+				"vfile-message": "^3.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/remark/node_modules/vfile-message": {
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-3.1.2.tgz",
+			"integrity": "sha512-QjSNP6Yxzyycd4SVOtmKKyTsSvClqBPJcd00Z0zuPj3hOIjg0rUPG6DbFGPvUKRgYyaIWLPKpuEclcuvb3H8qA==",
+			"dependencies": {
+				"@types/unist": "^2.0.0",
+				"unist-util-stringify-position": "^3.0.0"
 			},
 			"funding": {
 				"type": "opencollective",
@@ -11271,6 +12270,17 @@
 			"peer": true,
 			"dependencies": {
 				"queue-microtask": "^1.2.2"
+			}
+		},
+		"node_modules/sade": {
+			"version": "1.8.1",
+			"resolved": "https://registry.npmjs.org/sade/-/sade-1.8.1.tgz",
+			"integrity": "sha512-xal3CZX1Xlo/k4ApwCFrHVACi9fBqJ7V+mwhBsuf/1IOKbBy098Fex+Wa/5QMubw09pSZ/u8EY8PWgevJsXp1A==",
+			"dependencies": {
+				"mri": "^1.1.0"
+			},
+			"engines": {
+				"node": ">=6"
 			}
 		},
 		"node_modules/safe-buffer": {
@@ -12056,6 +13066,129 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/strip-markdown": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/strip-markdown/-/strip-markdown-5.0.0.tgz",
+			"integrity": "sha512-PXSts6Ta9A/TwGxVVSRlQs1ukJTAwwtbip2OheJEjPyfykaQ4sJSTnQWjLTI2vYWNts/R/91/csagp15W8n9gA==",
+			"dependencies": {
+				"@types/mdast": "^3.0.0",
+				"@types/unist": "^2.0.6",
+				"unified": "^10.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/strip-markdown/node_modules/bail": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/bail/-/bail-2.0.2.tgz",
+			"integrity": "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==",
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/wooorm"
+			}
+		},
+		"node_modules/strip-markdown/node_modules/is-buffer": {
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.5.tgz",
+			"integrity": "sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			],
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/strip-markdown/node_modules/is-plain-obj": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.0.0.tgz",
+			"integrity": "sha512-NXRbBtUdBioI73y/HmOhogw/U5msYPC9DAtGkJXeFcFWSFZw0mCUsPxk/snTuJHzNKA8kLBK4rH97RMB1BfCXw==",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/strip-markdown/node_modules/trough": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/trough/-/trough-2.1.0.tgz",
+			"integrity": "sha512-AqTiAOLcj85xS7vQ8QkAV41hPDIJ71XJB4RCUrzo/1GM2CQwhkJGaf9Hgr7BOugMRpgGUrqRg/DrBDl4H40+8g==",
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/wooorm"
+			}
+		},
+		"node_modules/strip-markdown/node_modules/unified": {
+			"version": "10.1.2",
+			"resolved": "https://registry.npmjs.org/unified/-/unified-10.1.2.tgz",
+			"integrity": "sha512-pUSWAi/RAnVy1Pif2kAoeWNBa3JVrx0MId2LASj8G+7AiHWoKZNTomq6LG326T68U7/e263X6fTdcXIy7XnF7Q==",
+			"dependencies": {
+				"@types/unist": "^2.0.0",
+				"bail": "^2.0.0",
+				"extend": "^3.0.0",
+				"is-buffer": "^2.0.0",
+				"is-plain-obj": "^4.0.0",
+				"trough": "^2.0.0",
+				"vfile": "^5.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/strip-markdown/node_modules/unist-util-stringify-position": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-3.0.2.tgz",
+			"integrity": "sha512-7A6eiDCs9UtjcwZOcCpM4aPII3bAAGv13E96IkawkOAW0OhH+yRxtY0lzo8KiHpzEMfH7Q+FizUmwp8Iqy5EWg==",
+			"dependencies": {
+				"@types/unist": "^2.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/strip-markdown/node_modules/vfile": {
+			"version": "5.3.2",
+			"resolved": "https://registry.npmjs.org/vfile/-/vfile-5.3.2.tgz",
+			"integrity": "sha512-w0PLIugRY3Crkgw89TeMvHCzqCs/zpreR31hl4D92y6SOE07+bfJe+dK5Q2akwS+i/c801kzjoOr9gMcTe6IAA==",
+			"dependencies": {
+				"@types/unist": "^2.0.0",
+				"is-buffer": "^2.0.0",
+				"unist-util-stringify-position": "^3.0.0",
+				"vfile-message": "^3.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/strip-markdown/node_modules/vfile-message": {
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-3.1.2.tgz",
+			"integrity": "sha512-QjSNP6Yxzyycd4SVOtmKKyTsSvClqBPJcd00Z0zuPj3hOIjg0rUPG6DbFGPvUKRgYyaIWLPKpuEclcuvb3H8qA==",
+			"dependencies": {
+				"@types/unist": "^2.0.0",
+				"unist-util-stringify-position": "^3.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
 			}
 		},
 		"node_modules/striptags": {
@@ -13019,6 +14152,23 @@
 			"peer": true,
 			"bin": {
 				"uuid": "dist/bin/uuid"
+			}
+		},
+		"node_modules/uvu": {
+			"version": "0.5.3",
+			"resolved": "https://registry.npmjs.org/uvu/-/uvu-0.5.3.tgz",
+			"integrity": "sha512-brFwqA3FXzilmtnIyJ+CxdkInkY/i4ErvP7uV0DnUVxQcQ55reuHphorpF+tZoVHK2MniZ/VJzI7zJQoc9T9Yw==",
+			"dependencies": {
+				"dequal": "^2.0.0",
+				"diff": "^5.0.0",
+				"kleur": "^4.0.3",
+				"sade": "^1.7.3"
+			},
+			"bin": {
+				"uvu": "bin.js"
+			},
+			"engines": {
+				"node": ">=8"
 			}
 		},
 		"node_modules/v-click-outside": {
@@ -16305,6 +17455,14 @@
 				"@types/node": "*"
 			}
 		},
+		"@types/debug": {
+			"version": "4.1.7",
+			"resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.7.tgz",
+			"integrity": "sha512-9AonUzyTjXXhEOa0DnqpzZi6VHlqKMswga9EXjpXnnqxwLtdvPPtlO8evrI5D9S6asFRCQ6v+wpiUKbw+vKqyg==",
+			"requires": {
+				"@types/ms": "*"
+			}
+		},
 		"@types/eslint": {
 			"version": "7.28.2",
 			"resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-7.28.2.tgz",
@@ -16399,6 +17557,11 @@
 			"dev": true,
 			"peer": true
 		},
+		"@types/ms": {
+			"version": "0.7.31",
+			"resolved": "https://registry.npmjs.org/@types/ms/-/ms-0.7.31.tgz",
+			"integrity": "sha512-iiUgKzV9AuaEkZqkOLDIvlQiL6ltuZd9tGcW3gwpnX8JbuiuhFlEGmmFXEXkN50Cvq7Os88IY2v0dkDqXYWVgA=="
+		},
 		"@types/node": {
 			"version": "14.0.26"
 		},
@@ -16475,7 +17638,9 @@
 			}
 		},
 		"@types/unist": {
-			"version": "2.0.3"
+			"version": "2.0.6",
+			"resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.6.tgz",
+			"integrity": "sha512-PBjIUxZHOuj0R15/xuwJYjFi+KZdNFrehocChv4g5hu6aFroHue8m0lBP0POdK2nKzbw0cgV1mws8+V/JAcEkQ=="
 		},
 		"@types/ws": {
 			"version": "8.2.2",
@@ -18107,6 +19272,21 @@
 				}
 			}
 		},
+		"decode-named-character-reference": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/decode-named-character-reference/-/decode-named-character-reference-1.0.1.tgz",
+			"integrity": "sha512-YV/0HQHreRwKb7uBopyIkLG17jG6Sv2qUchk9qSoVJ2f+flwRsPNBO0hAnjt6mTNYUT+vw9Gy2ihXg4sUWPi2w==",
+			"requires": {
+				"character-entities": "^2.0.0"
+			},
+			"dependencies": {
+				"character-entities": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/character-entities/-/character-entities-2.0.1.tgz",
+					"integrity": "sha512-OzmutCf2Kmc+6DrFrrPS8/tDh2+DpnrfzdICHWhcVC9eOd0N1PXmQEE1a8iM4IziIAG+8tmTq3K+oo0ubH6RRQ=="
+				}
+			}
+		},
 		"deep-equal": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.1.1.tgz",
@@ -18192,6 +19372,11 @@
 			"dev": true,
 			"peer": true
 		},
+		"dequal": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.2.tgz",
+			"integrity": "sha512-q9K8BlJVxK7hQYqa6XISGmBZbtQQWVXSrRrWreHC94rMt1QL/Impruc+7p2CYSYuVIUr+YCt6hjrs1kkdJRTug=="
+		},
 		"des.js": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/des.js/-/des.js-1.0.1.tgz",
@@ -18216,6 +19401,11 @@
 			"integrity": "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==",
 			"dev": true,
 			"peer": true
+		},
+		"diff": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/diff/-/diff-5.0.0.tgz",
+			"integrity": "sha512-/VTCrvm5Z0JGty/BWHljh+BAiw3IK+2j87NGMu8Nwc/f48WoDAC395uomO9ZD117ZOBaHmkX1oyLvkVM/aIT3w=="
 		},
 		"diffie-hellman": {
 			"version": "5.0.3",
@@ -20662,6 +21852,11 @@
 			"dev": true,
 			"peer": true
 		},
+		"kleur": {
+			"version": "4.1.4",
+			"resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.4.tgz",
+			"integrity": "sha512-8QADVssbrFjivHWQU7KkMgptGTl6WAcSdlbBPY4uNF+mWr6DGcKrvY2w4FQJoXch7+fKMjj0dRrL75vk3k23OA=="
+		},
 		"klona": {
 			"version": "2.0.5",
 			"resolved": "https://registry.npmjs.org/klona/-/klona-2.0.5.tgz",
@@ -20773,6 +21968,11 @@
 			"dev": true,
 			"peer": true
 		},
+		"longest-streak": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-3.0.1.tgz",
+			"integrity": "sha512-cHlYSUpL2s7Fb3394mYxwTYj8niTaNHUCLr0qdiCXQfSjfuA7CKofpX2uSwEfFDQ0EB7JcnMnm+GjbqqoinYYg=="
+		},
 		"loose-envify": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
@@ -20855,6 +22055,35 @@
 				}
 			}
 		},
+		"mdast-util-from-markdown": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-1.2.0.tgz",
+			"integrity": "sha512-iZJyyvKD1+K7QX1b5jXdE7Sc5dtoTry1vzV28UZZe8Z1xVnB/czKntJ7ZAkG0tANqRnBF6p3p7GpU1y19DTf2Q==",
+			"requires": {
+				"@types/mdast": "^3.0.0",
+				"@types/unist": "^2.0.0",
+				"decode-named-character-reference": "^1.0.0",
+				"mdast-util-to-string": "^3.1.0",
+				"micromark": "^3.0.0",
+				"micromark-util-decode-numeric-character-reference": "^1.0.0",
+				"micromark-util-decode-string": "^1.0.0",
+				"micromark-util-normalize-identifier": "^1.0.0",
+				"micromark-util-symbol": "^1.0.0",
+				"micromark-util-types": "^1.0.0",
+				"unist-util-stringify-position": "^3.0.0",
+				"uvu": "^0.5.0"
+			},
+			"dependencies": {
+				"unist-util-stringify-position": {
+					"version": "3.0.2",
+					"resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-3.0.2.tgz",
+					"integrity": "sha512-7A6eiDCs9UtjcwZOcCpM4aPII3bAAGv13E96IkawkOAW0OhH+yRxtY0lzo8KiHpzEMfH7Q+FizUmwp8Iqy5EWg==",
+					"requires": {
+						"@types/unist": "^2.0.0"
+					}
+				}
+			}
+		},
 		"mdast-util-to-hast": {
 			"version": "10.1.1",
 			"requires": {
@@ -20884,6 +22113,56 @@
 					}
 				}
 			}
+		},
+		"mdast-util-to-markdown": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/mdast-util-to-markdown/-/mdast-util-to-markdown-1.3.0.tgz",
+			"integrity": "sha512-6tUSs4r+KK4JGTTiQ7FfHmVOaDrLQJPmpjD6wPMlHGUVXoG9Vjc3jIeP+uyBWRf8clwB2blM+W7+KrlMYQnftA==",
+			"requires": {
+				"@types/mdast": "^3.0.0",
+				"@types/unist": "^2.0.0",
+				"longest-streak": "^3.0.0",
+				"mdast-util-to-string": "^3.0.0",
+				"micromark-util-decode-string": "^1.0.0",
+				"unist-util-visit": "^4.0.0",
+				"zwitch": "^2.0.0"
+			},
+			"dependencies": {
+				"unist-util-is": {
+					"version": "5.1.1",
+					"resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-5.1.1.tgz",
+					"integrity": "sha512-F5CZ68eYzuSvJjGhCLPL3cYx45IxkqXSetCcRgUXtbcm50X2L9oOWQlfUfDdAf+6Pd27YDblBfdtmsThXmwpbQ=="
+				},
+				"unist-util-visit": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-4.1.0.tgz",
+					"integrity": "sha512-n7lyhFKJfVZ9MnKtqbsqkQEk5P1KShj0+//V7mAcoI6bpbUjh3C/OG8HVD+pBihfh6Ovl01m8dkcv9HNqYajmQ==",
+					"requires": {
+						"@types/unist": "^2.0.0",
+						"unist-util-is": "^5.0.0",
+						"unist-util-visit-parents": "^5.0.0"
+					}
+				},
+				"unist-util-visit-parents": {
+					"version": "5.1.0",
+					"resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-5.1.0.tgz",
+					"integrity": "sha512-y+QVLcY5eR/YVpqDsLf/xh9R3Q2Y4HxkZTp7ViLDU6WtJCEcPmRzW1gpdWDCDIqIlhuPDXOgttqPlykrHYDekg==",
+					"requires": {
+						"@types/unist": "^2.0.0",
+						"unist-util-is": "^5.0.0"
+					}
+				},
+				"zwitch": {
+					"version": "2.0.2",
+					"resolved": "https://registry.npmjs.org/zwitch/-/zwitch-2.0.2.tgz",
+					"integrity": "sha512-JZxotl7SxAJH0j7dN4pxsTV6ZLXoLdGME+PsjkL/DaBrVryK9kTGq06GfKrwcSOqypP+fdXGoCHE36b99fWVoA=="
+				}
+			}
+		},
+		"mdast-util-to-string": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-3.1.0.tgz",
+			"integrity": "sha512-n4Vypz/DZgwo0iMHLQL49dJzlp7YtAJP+N07MZHpjPf/5XJuHUWstviF4Mn2jEiR/GNmtnRRqnwsXExk3igfFA=="
 		},
 		"mdurl": {
 			"version": "1.0.1"
@@ -21160,6 +22439,233 @@
 			"dev": true,
 			"peer": true
 		},
+		"micromark": {
+			"version": "3.0.10",
+			"resolved": "https://registry.npmjs.org/micromark/-/micromark-3.0.10.tgz",
+			"integrity": "sha512-ryTDy6UUunOXy2HPjelppgJ2sNfcPz1pLlMdA6Rz9jPzhLikWXv/irpWV/I2jd68Uhmny7hHxAlAhk4+vWggpg==",
+			"requires": {
+				"@types/debug": "^4.0.0",
+				"debug": "^4.0.0",
+				"decode-named-character-reference": "^1.0.0",
+				"micromark-core-commonmark": "^1.0.1",
+				"micromark-factory-space": "^1.0.0",
+				"micromark-util-character": "^1.0.0",
+				"micromark-util-chunked": "^1.0.0",
+				"micromark-util-combine-extensions": "^1.0.0",
+				"micromark-util-decode-numeric-character-reference": "^1.0.0",
+				"micromark-util-encode": "^1.0.0",
+				"micromark-util-normalize-identifier": "^1.0.0",
+				"micromark-util-resolve-all": "^1.0.0",
+				"micromark-util-sanitize-uri": "^1.0.0",
+				"micromark-util-subtokenize": "^1.0.0",
+				"micromark-util-symbol": "^1.0.0",
+				"micromark-util-types": "^1.0.1",
+				"uvu": "^0.5.0"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "4.3.4",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+					"integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+					"requires": {
+						"ms": "2.1.2"
+					}
+				},
+				"ms": {
+					"version": "2.1.2",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+				}
+			}
+		},
+		"micromark-core-commonmark": {
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/micromark-core-commonmark/-/micromark-core-commonmark-1.0.6.tgz",
+			"integrity": "sha512-K+PkJTxqjFfSNkfAhp4GB+cZPfQd6dxtTXnf+RjZOV7T4EEXnvgzOcnp+eSTmpGk9d1S9sL6/lqrgSNn/s0HZA==",
+			"requires": {
+				"decode-named-character-reference": "^1.0.0",
+				"micromark-factory-destination": "^1.0.0",
+				"micromark-factory-label": "^1.0.0",
+				"micromark-factory-space": "^1.0.0",
+				"micromark-factory-title": "^1.0.0",
+				"micromark-factory-whitespace": "^1.0.0",
+				"micromark-util-character": "^1.0.0",
+				"micromark-util-chunked": "^1.0.0",
+				"micromark-util-classify-character": "^1.0.0",
+				"micromark-util-html-tag-name": "^1.0.0",
+				"micromark-util-normalize-identifier": "^1.0.0",
+				"micromark-util-resolve-all": "^1.0.0",
+				"micromark-util-subtokenize": "^1.0.0",
+				"micromark-util-symbol": "^1.0.0",
+				"micromark-util-types": "^1.0.1",
+				"uvu": "^0.5.0"
+			}
+		},
+		"micromark-factory-destination": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/micromark-factory-destination/-/micromark-factory-destination-1.0.0.tgz",
+			"integrity": "sha512-eUBA7Rs1/xtTVun9TmV3gjfPz2wEwgK5R5xcbIM5ZYAtvGF6JkyaDsj0agx8urXnO31tEO6Ug83iVH3tdedLnw==",
+			"requires": {
+				"micromark-util-character": "^1.0.0",
+				"micromark-util-symbol": "^1.0.0",
+				"micromark-util-types": "^1.0.0"
+			}
+		},
+		"micromark-factory-label": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/micromark-factory-label/-/micromark-factory-label-1.0.2.tgz",
+			"integrity": "sha512-CTIwxlOnU7dEshXDQ+dsr2n+yxpP0+fn271pu0bwDIS8uqfFcumXpj5mLn3hSC8iw2MUr6Gx8EcKng1dD7i6hg==",
+			"requires": {
+				"micromark-util-character": "^1.0.0",
+				"micromark-util-symbol": "^1.0.0",
+				"micromark-util-types": "^1.0.0",
+				"uvu": "^0.5.0"
+			}
+		},
+		"micromark-factory-space": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/micromark-factory-space/-/micromark-factory-space-1.0.0.tgz",
+			"integrity": "sha512-qUmqs4kj9a5yBnk3JMLyjtWYN6Mzfcx8uJfi5XAveBniDevmZasdGBba5b4QsvRcAkmvGo5ACmSUmyGiKTLZew==",
+			"requires": {
+				"micromark-util-character": "^1.0.0",
+				"micromark-util-types": "^1.0.0"
+			}
+		},
+		"micromark-factory-title": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/micromark-factory-title/-/micromark-factory-title-1.0.2.tgz",
+			"integrity": "sha512-zily+Nr4yFqgMGRKLpTVsNl5L4PMu485fGFDOQJQBl2NFpjGte1e86zC0da93wf97jrc4+2G2GQudFMHn3IX+A==",
+			"requires": {
+				"micromark-factory-space": "^1.0.0",
+				"micromark-util-character": "^1.0.0",
+				"micromark-util-symbol": "^1.0.0",
+				"micromark-util-types": "^1.0.0",
+				"uvu": "^0.5.0"
+			}
+		},
+		"micromark-factory-whitespace": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/micromark-factory-whitespace/-/micromark-factory-whitespace-1.0.0.tgz",
+			"integrity": "sha512-Qx7uEyahU1lt1RnsECBiuEbfr9INjQTGa6Err+gF3g0Tx4YEviPbqqGKNv/NrBaE7dVHdn1bVZKM/n5I/Bak7A==",
+			"requires": {
+				"micromark-factory-space": "^1.0.0",
+				"micromark-util-character": "^1.0.0",
+				"micromark-util-symbol": "^1.0.0",
+				"micromark-util-types": "^1.0.0"
+			}
+		},
+		"micromark-util-character": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-1.1.0.tgz",
+			"integrity": "sha512-agJ5B3unGNJ9rJvADMJ5ZiYjBRyDpzKAOk01Kpi1TKhlT1APx3XZk6eN7RtSz1erbWHC2L8T3xLZ81wdtGRZzg==",
+			"requires": {
+				"micromark-util-symbol": "^1.0.0",
+				"micromark-util-types": "^1.0.0"
+			}
+		},
+		"micromark-util-chunked": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/micromark-util-chunked/-/micromark-util-chunked-1.0.0.tgz",
+			"integrity": "sha512-5e8xTis5tEZKgesfbQMKRCyzvffRRUX+lK/y+DvsMFdabAicPkkZV6gO+FEWi9RfuKKoxxPwNL+dFF0SMImc1g==",
+			"requires": {
+				"micromark-util-symbol": "^1.0.0"
+			}
+		},
+		"micromark-util-classify-character": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/micromark-util-classify-character/-/micromark-util-classify-character-1.0.0.tgz",
+			"integrity": "sha512-F8oW2KKrQRb3vS5ud5HIqBVkCqQi224Nm55o5wYLzY/9PwHGXC01tr3d7+TqHHz6zrKQ72Okwtvm/xQm6OVNZA==",
+			"requires": {
+				"micromark-util-character": "^1.0.0",
+				"micromark-util-symbol": "^1.0.0",
+				"micromark-util-types": "^1.0.0"
+			}
+		},
+		"micromark-util-combine-extensions": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/micromark-util-combine-extensions/-/micromark-util-combine-extensions-1.0.0.tgz",
+			"integrity": "sha512-J8H058vFBdo/6+AsjHp2NF7AJ02SZtWaVUjsayNFeAiydTxUwViQPxN0Hf8dp4FmCQi0UUFovFsEyRSUmFH3MA==",
+			"requires": {
+				"micromark-util-chunked": "^1.0.0",
+				"micromark-util-types": "^1.0.0"
+			}
+		},
+		"micromark-util-decode-numeric-character-reference": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/micromark-util-decode-numeric-character-reference/-/micromark-util-decode-numeric-character-reference-1.0.0.tgz",
+			"integrity": "sha512-OzO9AI5VUtrTD7KSdagf4MWgHMtET17Ua1fIpXTpuhclCqD8egFWo85GxSGvxgkGS74bEahvtM0WP0HjvV0e4w==",
+			"requires": {
+				"micromark-util-symbol": "^1.0.0"
+			}
+		},
+		"micromark-util-decode-string": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/micromark-util-decode-string/-/micromark-util-decode-string-1.0.2.tgz",
+			"integrity": "sha512-DLT5Ho02qr6QWVNYbRZ3RYOSSWWFuH3tJexd3dgN1odEuPNxCngTCXJum7+ViRAd9BbdxCvMToPOD/IvVhzG6Q==",
+			"requires": {
+				"decode-named-character-reference": "^1.0.0",
+				"micromark-util-character": "^1.0.0",
+				"micromark-util-decode-numeric-character-reference": "^1.0.0",
+				"micromark-util-symbol": "^1.0.0"
+			}
+		},
+		"micromark-util-encode": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/micromark-util-encode/-/micromark-util-encode-1.0.1.tgz",
+			"integrity": "sha512-U2s5YdnAYexjKDel31SVMPbfi+eF8y1U4pfiRW/Y8EFVCy/vgxk/2wWTxzcqE71LHtCuCzlBDRU2a5CQ5j+mQA=="
+		},
+		"micromark-util-html-tag-name": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/micromark-util-html-tag-name/-/micromark-util-html-tag-name-1.0.0.tgz",
+			"integrity": "sha512-NenEKIshW2ZI/ERv9HtFNsrn3llSPZtY337LID/24WeLqMzeZhBEE6BQ0vS2ZBjshm5n40chKtJ3qjAbVV8S0g=="
+		},
+		"micromark-util-normalize-identifier": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/micromark-util-normalize-identifier/-/micromark-util-normalize-identifier-1.0.0.tgz",
+			"integrity": "sha512-yg+zrL14bBTFrQ7n35CmByWUTFsgst5JhA4gJYoty4Dqzj4Z4Fr/DHekSS5aLfH9bdlfnSvKAWsAgJhIbogyBg==",
+			"requires": {
+				"micromark-util-symbol": "^1.0.0"
+			}
+		},
+		"micromark-util-resolve-all": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/micromark-util-resolve-all/-/micromark-util-resolve-all-1.0.0.tgz",
+			"integrity": "sha512-CB/AGk98u50k42kvgaMM94wzBqozSzDDaonKU7P7jwQIuH2RU0TeBqGYJz2WY1UdihhjweivStrJ2JdkdEmcfw==",
+			"requires": {
+				"micromark-util-types": "^1.0.0"
+			}
+		},
+		"micromark-util-sanitize-uri": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-1.0.0.tgz",
+			"integrity": "sha512-cCxvBKlmac4rxCGx6ejlIviRaMKZc0fWm5HdCHEeDWRSkn44l6NdYVRyU+0nT1XC72EQJMZV8IPHF+jTr56lAg==",
+			"requires": {
+				"micromark-util-character": "^1.0.0",
+				"micromark-util-encode": "^1.0.0",
+				"micromark-util-symbol": "^1.0.0"
+			}
+		},
+		"micromark-util-subtokenize": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/micromark-util-subtokenize/-/micromark-util-subtokenize-1.0.2.tgz",
+			"integrity": "sha512-d90uqCnXp/cy4G881Ub4psE57Sf8YD0pim9QdjCRNjfas2M1u6Lbt+XZK9gnHL2XFhnozZiEdCa9CNfXSfQ6xA==",
+			"requires": {
+				"micromark-util-chunked": "^1.0.0",
+				"micromark-util-symbol": "^1.0.0",
+				"micromark-util-types": "^1.0.0",
+				"uvu": "^0.5.0"
+			}
+		},
+		"micromark-util-symbol": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-1.0.1.tgz",
+			"integrity": "sha512-oKDEMK2u5qqAptasDAwWDXq0tG9AssVwAx3E9bBF3t/shRIGsWIRG+cGafs2p/SnDSOecnt6hZPCE2o6lHfFmQ=="
+		},
+		"micromark-util-types": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-1.0.2.tgz",
+			"integrity": "sha512-DCfg/T8fcrhrRKTPjRrw/5LLvdGV7BHySf/1LOZx7TzWZdYRjogNtyNq885z3nNallwr3QUKARjqvHqX1/7t+w=="
+		},
 		"miller-rabin": {
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-4.0.1.tgz",
@@ -21283,6 +22789,11 @@
 			"version": "2.29.3",
 			"resolved": "https://registry.npmjs.org/moment/-/moment-2.29.3.tgz",
 			"integrity": "sha512-c6YRvhEo//6T2Jz/vVtYzqBzwvPT95JBQ+smCytzf7c50oMZRsR/a4w88aD34I+/QVSfnoAnSBFPJHItlOMJVw=="
+		},
+		"mri": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/mri/-/mri-1.2.0.tgz",
+			"integrity": "sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA=="
 		},
 		"ms": {
 			"version": "2.0.0"
@@ -22180,6 +23691,81 @@
 				"hast-to-hyperscript": "^9.0.0"
 			}
 		},
+		"remark": {
+			"version": "14.0.2",
+			"resolved": "https://registry.npmjs.org/remark/-/remark-14.0.2.tgz",
+			"integrity": "sha512-A3ARm2V4BgiRXaUo5K0dRvJ1lbogrbXnhkJRmD0yw092/Yl0kOCZt1k9ZeElEwkZsWGsMumz6qL5MfNJH9nOBA==",
+			"requires": {
+				"@types/mdast": "^3.0.0",
+				"remark-parse": "^10.0.0",
+				"remark-stringify": "^10.0.0",
+				"unified": "^10.0.0"
+			},
+			"dependencies": {
+				"bail": {
+					"version": "2.0.2",
+					"resolved": "https://registry.npmjs.org/bail/-/bail-2.0.2.tgz",
+					"integrity": "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw=="
+				},
+				"is-buffer": {
+					"version": "2.0.5",
+					"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.5.tgz",
+					"integrity": "sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ=="
+				},
+				"is-plain-obj": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.0.0.tgz",
+					"integrity": "sha512-NXRbBtUdBioI73y/HmOhogw/U5msYPC9DAtGkJXeFcFWSFZw0mCUsPxk/snTuJHzNKA8kLBK4rH97RMB1BfCXw=="
+				},
+				"trough": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/trough/-/trough-2.1.0.tgz",
+					"integrity": "sha512-AqTiAOLcj85xS7vQ8QkAV41hPDIJ71XJB4RCUrzo/1GM2CQwhkJGaf9Hgr7BOugMRpgGUrqRg/DrBDl4H40+8g=="
+				},
+				"unified": {
+					"version": "10.1.2",
+					"resolved": "https://registry.npmjs.org/unified/-/unified-10.1.2.tgz",
+					"integrity": "sha512-pUSWAi/RAnVy1Pif2kAoeWNBa3JVrx0MId2LASj8G+7AiHWoKZNTomq6LG326T68U7/e263X6fTdcXIy7XnF7Q==",
+					"requires": {
+						"@types/unist": "^2.0.0",
+						"bail": "^2.0.0",
+						"extend": "^3.0.0",
+						"is-buffer": "^2.0.0",
+						"is-plain-obj": "^4.0.0",
+						"trough": "^2.0.0",
+						"vfile": "^5.0.0"
+					}
+				},
+				"unist-util-stringify-position": {
+					"version": "3.0.2",
+					"resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-3.0.2.tgz",
+					"integrity": "sha512-7A6eiDCs9UtjcwZOcCpM4aPII3bAAGv13E96IkawkOAW0OhH+yRxtY0lzo8KiHpzEMfH7Q+FizUmwp8Iqy5EWg==",
+					"requires": {
+						"@types/unist": "^2.0.0"
+					}
+				},
+				"vfile": {
+					"version": "5.3.2",
+					"resolved": "https://registry.npmjs.org/vfile/-/vfile-5.3.2.tgz",
+					"integrity": "sha512-w0PLIugRY3Crkgw89TeMvHCzqCs/zpreR31hl4D92y6SOE07+bfJe+dK5Q2akwS+i/c801kzjoOr9gMcTe6IAA==",
+					"requires": {
+						"@types/unist": "^2.0.0",
+						"is-buffer": "^2.0.0",
+						"unist-util-stringify-position": "^3.0.0",
+						"vfile-message": "^3.0.0"
+					}
+				},
+				"vfile-message": {
+					"version": "3.1.2",
+					"resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-3.1.2.tgz",
+					"integrity": "sha512-QjSNP6Yxzyycd4SVOtmKKyTsSvClqBPJcd00Z0zuPj3hOIjg0rUPG6DbFGPvUKRgYyaIWLPKpuEclcuvb3H8qA==",
+					"requires": {
+						"@types/unist": "^2.0.0",
+						"unist-util-stringify-position": "^3.0.0"
+					}
+				}
+			}
+		},
 		"remark-breaks": {
 			"version": "2.0.0"
 		},
@@ -22216,10 +23802,158 @@
 				}
 			}
 		},
+		"remark-parse": {
+			"version": "10.0.1",
+			"resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-10.0.1.tgz",
+			"integrity": "sha512-1fUyHr2jLsVOkhbvPRBJ5zTKZZyD6yZzYaWCS6BPBdQ8vEMBCH+9zNCDA6tET/zHCi/jLqjCWtlJZUPk+DbnFw==",
+			"requires": {
+				"@types/mdast": "^3.0.0",
+				"mdast-util-from-markdown": "^1.0.0",
+				"unified": "^10.0.0"
+			},
+			"dependencies": {
+				"bail": {
+					"version": "2.0.2",
+					"resolved": "https://registry.npmjs.org/bail/-/bail-2.0.2.tgz",
+					"integrity": "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw=="
+				},
+				"is-buffer": {
+					"version": "2.0.5",
+					"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.5.tgz",
+					"integrity": "sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ=="
+				},
+				"is-plain-obj": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.0.0.tgz",
+					"integrity": "sha512-NXRbBtUdBioI73y/HmOhogw/U5msYPC9DAtGkJXeFcFWSFZw0mCUsPxk/snTuJHzNKA8kLBK4rH97RMB1BfCXw=="
+				},
+				"trough": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/trough/-/trough-2.1.0.tgz",
+					"integrity": "sha512-AqTiAOLcj85xS7vQ8QkAV41hPDIJ71XJB4RCUrzo/1GM2CQwhkJGaf9Hgr7BOugMRpgGUrqRg/DrBDl4H40+8g=="
+				},
+				"unified": {
+					"version": "10.1.2",
+					"resolved": "https://registry.npmjs.org/unified/-/unified-10.1.2.tgz",
+					"integrity": "sha512-pUSWAi/RAnVy1Pif2kAoeWNBa3JVrx0MId2LASj8G+7AiHWoKZNTomq6LG326T68U7/e263X6fTdcXIy7XnF7Q==",
+					"requires": {
+						"@types/unist": "^2.0.0",
+						"bail": "^2.0.0",
+						"extend": "^3.0.0",
+						"is-buffer": "^2.0.0",
+						"is-plain-obj": "^4.0.0",
+						"trough": "^2.0.0",
+						"vfile": "^5.0.0"
+					}
+				},
+				"unist-util-stringify-position": {
+					"version": "3.0.2",
+					"resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-3.0.2.tgz",
+					"integrity": "sha512-7A6eiDCs9UtjcwZOcCpM4aPII3bAAGv13E96IkawkOAW0OhH+yRxtY0lzo8KiHpzEMfH7Q+FizUmwp8Iqy5EWg==",
+					"requires": {
+						"@types/unist": "^2.0.0"
+					}
+				},
+				"vfile": {
+					"version": "5.3.2",
+					"resolved": "https://registry.npmjs.org/vfile/-/vfile-5.3.2.tgz",
+					"integrity": "sha512-w0PLIugRY3Crkgw89TeMvHCzqCs/zpreR31hl4D92y6SOE07+bfJe+dK5Q2akwS+i/c801kzjoOr9gMcTe6IAA==",
+					"requires": {
+						"@types/unist": "^2.0.0",
+						"is-buffer": "^2.0.0",
+						"unist-util-stringify-position": "^3.0.0",
+						"vfile-message": "^3.0.0"
+					}
+				},
+				"vfile-message": {
+					"version": "3.1.2",
+					"resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-3.1.2.tgz",
+					"integrity": "sha512-QjSNP6Yxzyycd4SVOtmKKyTsSvClqBPJcd00Z0zuPj3hOIjg0rUPG6DbFGPvUKRgYyaIWLPKpuEclcuvb3H8qA==",
+					"requires": {
+						"@types/unist": "^2.0.0",
+						"unist-util-stringify-position": "^3.0.0"
+					}
+				}
+			}
+		},
 		"remark-rehype": {
 			"version": "8.0.0",
 			"requires": {
 				"mdast-util-to-hast": "^10.0.0"
+			}
+		},
+		"remark-stringify": {
+			"version": "10.0.2",
+			"resolved": "https://registry.npmjs.org/remark-stringify/-/remark-stringify-10.0.2.tgz",
+			"integrity": "sha512-6wV3pvbPvHkbNnWB0wdDvVFHOe1hBRAx1Q/5g/EpH4RppAII6J8Gnwe7VbHuXaoKIF6LAg6ExTel/+kNqSQ7lw==",
+			"requires": {
+				"@types/mdast": "^3.0.0",
+				"mdast-util-to-markdown": "^1.0.0",
+				"unified": "^10.0.0"
+			},
+			"dependencies": {
+				"bail": {
+					"version": "2.0.2",
+					"resolved": "https://registry.npmjs.org/bail/-/bail-2.0.2.tgz",
+					"integrity": "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw=="
+				},
+				"is-buffer": {
+					"version": "2.0.5",
+					"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.5.tgz",
+					"integrity": "sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ=="
+				},
+				"is-plain-obj": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.0.0.tgz",
+					"integrity": "sha512-NXRbBtUdBioI73y/HmOhogw/U5msYPC9DAtGkJXeFcFWSFZw0mCUsPxk/snTuJHzNKA8kLBK4rH97RMB1BfCXw=="
+				},
+				"trough": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/trough/-/trough-2.1.0.tgz",
+					"integrity": "sha512-AqTiAOLcj85xS7vQ8QkAV41hPDIJ71XJB4RCUrzo/1GM2CQwhkJGaf9Hgr7BOugMRpgGUrqRg/DrBDl4H40+8g=="
+				},
+				"unified": {
+					"version": "10.1.2",
+					"resolved": "https://registry.npmjs.org/unified/-/unified-10.1.2.tgz",
+					"integrity": "sha512-pUSWAi/RAnVy1Pif2kAoeWNBa3JVrx0MId2LASj8G+7AiHWoKZNTomq6LG326T68U7/e263X6fTdcXIy7XnF7Q==",
+					"requires": {
+						"@types/unist": "^2.0.0",
+						"bail": "^2.0.0",
+						"extend": "^3.0.0",
+						"is-buffer": "^2.0.0",
+						"is-plain-obj": "^4.0.0",
+						"trough": "^2.0.0",
+						"vfile": "^5.0.0"
+					}
+				},
+				"unist-util-stringify-position": {
+					"version": "3.0.2",
+					"resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-3.0.2.tgz",
+					"integrity": "sha512-7A6eiDCs9UtjcwZOcCpM4aPII3bAAGv13E96IkawkOAW0OhH+yRxtY0lzo8KiHpzEMfH7Q+FizUmwp8Iqy5EWg==",
+					"requires": {
+						"@types/unist": "^2.0.0"
+					}
+				},
+				"vfile": {
+					"version": "5.3.2",
+					"resolved": "https://registry.npmjs.org/vfile/-/vfile-5.3.2.tgz",
+					"integrity": "sha512-w0PLIugRY3Crkgw89TeMvHCzqCs/zpreR31hl4D92y6SOE07+bfJe+dK5Q2akwS+i/c801kzjoOr9gMcTe6IAA==",
+					"requires": {
+						"@types/unist": "^2.0.0",
+						"is-buffer": "^2.0.0",
+						"unist-util-stringify-position": "^3.0.0",
+						"vfile-message": "^3.0.0"
+					}
+				},
+				"vfile-message": {
+					"version": "3.1.2",
+					"resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-3.1.2.tgz",
+					"integrity": "sha512-QjSNP6Yxzyycd4SVOtmKKyTsSvClqBPJcd00Z0zuPj3hOIjg0rUPG6DbFGPvUKRgYyaIWLPKpuEclcuvb3H8qA==",
+					"requires": {
+						"@types/unist": "^2.0.0",
+						"unist-util-stringify-position": "^3.0.0"
+					}
+				}
 			}
 		},
 		"repeat-string": {
@@ -22326,6 +24060,14 @@
 			"peer": true,
 			"requires": {
 				"queue-microtask": "^1.2.2"
+			}
+		},
+		"sade": {
+			"version": "1.8.1",
+			"resolved": "https://registry.npmjs.org/sade/-/sade-1.8.1.tgz",
+			"integrity": "sha512-xal3CZX1Xlo/k4ApwCFrHVACi9fBqJ7V+mwhBsuf/1IOKbBy098Fex+Wa/5QMubw09pSZ/u8EY8PWgevJsXp1A==",
+			"requires": {
+				"mri": "^1.1.0"
 			}
 		},
 		"safe-buffer": {
@@ -22946,6 +24688,80 @@
 			"integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
 			"dev": true,
 			"peer": true
+		},
+		"strip-markdown": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/strip-markdown/-/strip-markdown-5.0.0.tgz",
+			"integrity": "sha512-PXSts6Ta9A/TwGxVVSRlQs1ukJTAwwtbip2OheJEjPyfykaQ4sJSTnQWjLTI2vYWNts/R/91/csagp15W8n9gA==",
+			"requires": {
+				"@types/mdast": "^3.0.0",
+				"@types/unist": "^2.0.6",
+				"unified": "^10.0.0"
+			},
+			"dependencies": {
+				"bail": {
+					"version": "2.0.2",
+					"resolved": "https://registry.npmjs.org/bail/-/bail-2.0.2.tgz",
+					"integrity": "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw=="
+				},
+				"is-buffer": {
+					"version": "2.0.5",
+					"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.5.tgz",
+					"integrity": "sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ=="
+				},
+				"is-plain-obj": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.0.0.tgz",
+					"integrity": "sha512-NXRbBtUdBioI73y/HmOhogw/U5msYPC9DAtGkJXeFcFWSFZw0mCUsPxk/snTuJHzNKA8kLBK4rH97RMB1BfCXw=="
+				},
+				"trough": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/trough/-/trough-2.1.0.tgz",
+					"integrity": "sha512-AqTiAOLcj85xS7vQ8QkAV41hPDIJ71XJB4RCUrzo/1GM2CQwhkJGaf9Hgr7BOugMRpgGUrqRg/DrBDl4H40+8g=="
+				},
+				"unified": {
+					"version": "10.1.2",
+					"resolved": "https://registry.npmjs.org/unified/-/unified-10.1.2.tgz",
+					"integrity": "sha512-pUSWAi/RAnVy1Pif2kAoeWNBa3JVrx0MId2LASj8G+7AiHWoKZNTomq6LG326T68U7/e263X6fTdcXIy7XnF7Q==",
+					"requires": {
+						"@types/unist": "^2.0.0",
+						"bail": "^2.0.0",
+						"extend": "^3.0.0",
+						"is-buffer": "^2.0.0",
+						"is-plain-obj": "^4.0.0",
+						"trough": "^2.0.0",
+						"vfile": "^5.0.0"
+					}
+				},
+				"unist-util-stringify-position": {
+					"version": "3.0.2",
+					"resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-3.0.2.tgz",
+					"integrity": "sha512-7A6eiDCs9UtjcwZOcCpM4aPII3bAAGv13E96IkawkOAW0OhH+yRxtY0lzo8KiHpzEMfH7Q+FizUmwp8Iqy5EWg==",
+					"requires": {
+						"@types/unist": "^2.0.0"
+					}
+				},
+				"vfile": {
+					"version": "5.3.2",
+					"resolved": "https://registry.npmjs.org/vfile/-/vfile-5.3.2.tgz",
+					"integrity": "sha512-w0PLIugRY3Crkgw89TeMvHCzqCs/zpreR31hl4D92y6SOE07+bfJe+dK5Q2akwS+i/c801kzjoOr9gMcTe6IAA==",
+					"requires": {
+						"@types/unist": "^2.0.0",
+						"is-buffer": "^2.0.0",
+						"unist-util-stringify-position": "^3.0.0",
+						"vfile-message": "^3.0.0"
+					}
+				},
+				"vfile-message": {
+					"version": "3.1.2",
+					"resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-3.1.2.tgz",
+					"integrity": "sha512-QjSNP6Yxzyycd4SVOtmKKyTsSvClqBPJcd00Z0zuPj3hOIjg0rUPG6DbFGPvUKRgYyaIWLPKpuEclcuvb3H8qA==",
+					"requires": {
+						"@types/unist": "^2.0.0",
+						"unist-util-stringify-position": "^3.0.0"
+					}
+				}
+			}
 		},
 		"striptags": {
 			"version": "3.2.0",
@@ -23626,6 +25442,17 @@
 			"resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
 			"integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
 			"peer": true
+		},
+		"uvu": {
+			"version": "0.5.3",
+			"resolved": "https://registry.npmjs.org/uvu/-/uvu-0.5.3.tgz",
+			"integrity": "sha512-brFwqA3FXzilmtnIyJ+CxdkInkY/i4ErvP7uV0DnUVxQcQ55reuHphorpF+tZoVHK2MniZ/VJzI7zJQoc9T9Yw==",
+			"requires": {
+				"dequal": "^2.0.0",
+				"diff": "^5.0.0",
+				"kleur": "^4.0.3",
+				"sade": "^1.7.3"
+			}
 		},
 		"v-click-outside": {
 			"version": "3.1.2"

--- a/package.json
+++ b/package.json
@@ -32,6 +32,8 @@
 		"@nextcloud/vue": "^5.3.1",
 		"@nextcloud/vue-dashboard": "^2.0.1",
 		"debounce": "^1.2.1",
+		"remark": "^14.0.2",
+		"strip-markdown": "^5.0.0",
 		"vue": "^2.6.14",
 		"vuex": "^3.6.2"
 	},

--- a/src/App.vue
+++ b/src/App.vue
@@ -56,9 +56,9 @@ import AppSidebar from '@nextcloud/vue/dist/Components/AppSidebar'
 import Content from '@nextcloud/vue/dist/Components/Content'
 import EmptyContent from '@nextcloud/vue/dist/Components/EmptyContent'
 import { loadState } from '@nextcloud/initial-state'
-import Announcement from './Components/Announcement'
-import NewForm from './Components/NewForm'
-import { getAnnouncements } from './services/announcementsService'
+import Announcement from './Components/Announcement.vue'
+import NewForm from './Components/NewForm.vue'
+import { getAnnouncements } from './services/announcementsService.js'
 
 export default {
 	name: 'App',

--- a/src/Components/Announcement.vue
+++ b/src/Components/Announcement.vue
@@ -101,7 +101,7 @@ import {
 import {
 	deleteAnnouncement,
 	removeNotifications,
-} from '../services/announcementsService'
+} from '../services/announcementsService.js'
 
 export default {
 	name: 'Announcement',

--- a/src/Components/NewForm.vue
+++ b/src/Components/NewForm.vue
@@ -145,7 +145,7 @@ export default {
 
 			const plainMessage = await remark()
 				.use(strip, {
-					keep: ['blockquote', 'listItem'],
+					keep: ['blockquote', 'link', 'listItem'],
 				})
 				.process(this.message)
 

--- a/src/Components/NewForm.vue
+++ b/src/Components/NewForm.vue
@@ -82,7 +82,7 @@ import { loadState } from '@nextcloud/initial-state'
 import {
 	postAnnouncement,
 	searchGroups,
-} from '../services/announcementsService'
+} from '../services/announcementsService.js'
 import { showError } from '@nextcloud/dialogs'
 
 export default {

--- a/src/dashboard.js
+++ b/src/dashboard.js
@@ -24,7 +24,7 @@ import Vue from 'vue'
 import { generateFilePath } from '@nextcloud/router'
 import { getRequestToken } from '@nextcloud/auth'
 import { translate, translatePlural } from '@nextcloud/l10n'
-import Dashboard from './views/Dashboard'
+import Dashboard from './views/Dashboard.vue'
 
 // eslint-disable-next-line
 __webpack_nonce__ = btoa(getRequestToken())

--- a/src/main.js
+++ b/src/main.js
@@ -24,8 +24,8 @@ import Vue from 'vue'
 import { generateFilePath } from '@nextcloud/router'
 import { getRequestToken } from '@nextcloud/auth'
 import { translate, translatePlural } from '@nextcloud/l10n'
-import store from './store'
-import App from './App'
+import store from './store/index.js'
+import App from './App.vue'
 import Vuex from 'vuex'
 
 // Styles

--- a/src/services/announcementsService.js
+++ b/src/services/announcementsService.js
@@ -54,19 +54,23 @@ const searchGroups = async function(search) {
  *
  * @param {string} subject Short title of the announcement
  * @param {string} message Markdown body of the announcement
+ * @param {string} plainMessage Plain body of the announcement
  * @param {string[]} groups List of groups that can read the announcement
  * @param {boolean} activities Should activities be generated
  * @param {boolean} notifications Should notifications be generated
+ * @param {boolean} emails Should emails be sent
  * @param {boolean} comments Are comments allowed
  * @return {object} The axios response
  */
-const postAnnouncement = async function(subject, message, groups, activities, notifications, comments) {
+const postAnnouncement = async function(subject, message, plainMessage, groups, activities, notifications, emails, comments) {
 	return axios.post(generateOcsUrl('apps/announcementcenter/api/v1/announcements'), {
 		subject,
 		message,
+		plainMessage,
 		groups,
 		activities,
 		notifications,
+		emails,
 		comments,
 	})
 }

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -22,7 +22,7 @@
 
 import Vue from 'vue'
 import Vuex, { Store } from 'vuex'
-import announcementsStore from './announcementsStore'
+import announcementsStore from './announcementsStore.js'
 
 Vue.use(Vuex)
 

--- a/templates/admin.php
+++ b/templates/admin.php
@@ -55,6 +55,15 @@ script('announcementcenter', 'announcementcenter-admin');
 	</p>
 
 	<p>
+		<input id="announcementcenter_send_emails" name="send_emails"
+			   type="checkbox" class="checkbox" value="1"
+			   <?php if ($_['sendEmails']) {
+	print_unescaped('checked="checked"');
+} ?> />
+		<label for="announcementcenter_send_emails"><?php p($l->t('Send emails by default'));?></label><br/>
+	</p>
+
+	<p>
 		<input id="announcementcenter_allow_comments" name="allow_comments"
 			   type="checkbox" class="checkbox" value="1"
 			   <?php if ($_['allowComments']) {

--- a/tests/Controller/PageControllerTest.php
+++ b/tests/Controller/PageControllerTest.php
@@ -65,29 +65,33 @@ class PageControllerTest extends TestCase {
 
 	public function dataIndex(): array {
 		return [
-			[true, 'yes', true, 'no', false, 'no', false],
-			[false, 'no', false, 'yes', true, 'yes', true],
-			[false, 'no', false, 'no', false, 'yes', true],
+			[true, 'yes', true, 'no', false, 'no', false, 'no', false],
+			[false, 'no', false, 'yes', true, 'yes', true, 'yes', true],
+			[false, 'no', false, 'no', false, 'yes', true, 'yes', true],
 		];
 	}
 
 	/**
 	 * @dataProvider dataIndex
+	 *
 	 * @param bool $isAdmin
 	 * @param string $createActivitiesConfig
 	 * @param bool $createActivities
 	 * @param string $createNotificationsConfig
 	 * @param bool $createNotifications
+	 * @param string $sendEmailsConfig
+	 * @param bool $sendEmails
 	 * @param string $allowCommentsConfig
 	 * @param bool $allowComments
 	 */
-	public function testIndex(bool $isAdmin, string $createActivitiesConfig, bool $createActivities, string $createNotificationsConfig, bool $createNotifications, string $allowCommentsConfig, bool $allowComments) {
+	public function testIndex(bool $isAdmin, string $createActivitiesConfig, bool $createActivities, string $createNotificationsConfig, bool $createNotifications, string $sendEmailsConfig, bool $sendEmails, string $allowCommentsConfig, bool $allowComments) {
 		$this->manager->method('checkIsAdmin')
 			->willReturn($isAdmin);
 		$this->config->method('getAppValue')
 			->willReturnMap([
 				['announcementcenter', 'create_activities', 'yes', $createActivitiesConfig],
 				['announcementcenter', 'create_notifications', 'yes', $createNotificationsConfig],
+				['announcementcenter', 'send_emails', 'yes', $sendEmailsConfig],
 				['announcementcenter', 'allow_comments', 'yes', $allowCommentsConfig],
 			]);
 
@@ -96,6 +100,7 @@ class PageControllerTest extends TestCase {
 				['isAdmin', $isAdmin],
 				['createActivities', $createActivities],
 				['createNotifications', $createNotifications],
+				['sendEmails', $sendEmails],
 				['allowComments', $allowComments]
 			);
 

--- a/tests/ManagerTest.php
+++ b/tests/ManagerTest.php
@@ -117,14 +117,14 @@ class ManagerTest extends TestCase {
 		$this->expectException(\InvalidArgumentException::class);
 		$this->expectExceptionMessage('Invalid subject');
 		$this->expectExceptionCode(2);
-		$this->manager->announce('', '', '', 0, [], false);
+		$this->manager->announce('', '', '', '', 0, [], false);
 	}
 
 	public function testAnnounceSubjectTooLong(): void {
 		$this->expectException(\InvalidArgumentException::class);
 		$this->expectExceptionMessage('Invalid subject');
 		$this->expectExceptionCode(1);
-		$this->manager->announce(str_repeat('a', 513), '', '', 0, [], false);
+		$this->manager->announce(str_repeat('a', 513), '', '', '', 0, [], false);
 	}
 
 	public function testDelete(): void {

--- a/tests/ManagerTest.php
+++ b/tests/ManagerTest.php
@@ -213,10 +213,10 @@ class ManagerTest extends TestCase {
 
 	public function dataHasNotifications(): array {
 		return [
-			[23, false, true, 0, true],
-			[42, true, true, 0, true],
-			[72, false, false, 0, false],
-			[128, false, false, 55, true],
+			[23, false, true, false, 0],
+			[42, true, true, true, 0],
+			[72, false, false, false, 0],
+			[128, false, false, false, 55],
 		];
 	}
 
@@ -225,22 +225,15 @@ class ManagerTest extends TestCase {
 	 * @param int $id
 	 * @param bool $hasActivityJob
 	 * @param bool $hasNotificationJob
+	 * @param bool $hasEmailJob
 	 * @param int $numNotifications
 	 */
-	public function testHasNotifications(int $id, bool $hasActivityJob, bool $hasNotificationJob, int $numNotifications): void {
-		$this->jobList->expects($hasActivityJob ? self::once() : self::exactly(2))
+	public function testHasNotifications(int $id, bool $hasActivityJob, bool $hasNotificationJob, bool $hasEmailJob, int $numNotifications): void {
+		$this->jobList
 			->method('has')
 			->willReturnMap([
-				[BackgroundJob::class, [
-					'id' => $id,
-					'activities' => true,
-					'notifications' => true,
-				], $hasActivityJob && $hasNotificationJob],
-				[BackgroundJob::class, [
-					'id' => $id,
-					'activities' => false,
-					'notifications' => true,
-				], $hasNotificationJob],
+				[BackgroundJob::class, ['id' => $id, 'activities' => true, 'notifications' => true, 'emails' => true], $hasActivityJob && $hasNotificationJob],
+				[BackgroundJob::class, ['id' => $id, 'activities' => false, 'notifications' => true, 'emails' => true], $hasNotificationJob],
 			]);
 
 		if (!$hasNotificationJob) {
@@ -277,8 +270,8 @@ class ManagerTest extends TestCase {
 
 	public function dataRemoveNotifications(): array {
 		return [
-			[23, false],
-			[42, true],
+			[23, false, false],
+			[42, true, true],
 		];
 	}
 
@@ -286,39 +279,41 @@ class ManagerTest extends TestCase {
 	 * @dataProvider dataRemoveNotifications
 	 * @param int $id
 	 * @param bool $hasActivity
+	 * @param bool $hasEmail
 	 */
-	public function testRemoveNotifications(int $id, bool $hasActivity): void {
-		$this->jobList->expects(self::once())
+	public function testRemoveNotifications(int $id, bool $hasActivity, bool $hasEmail): void {
+		$this->jobList
 			->method('has')
-			->with(BackgroundJob::class, [
-				'id' => $id,
-				'activities' => true,
-				'notifications' => true,
-			])
-			->willReturn($hasActivity);
+			->willReturnMap([
+				[BackgroundJob::class, ['id' => $id, 'activities' => false, 'notifications' => true, 'emails' => false], !$hasActivity],
+				[BackgroundJob::class, ['id' => $id, 'activities' => true, 'notifications' => true, 'emails' => true], $hasActivity],
+			]);
 
 		if ($hasActivity) {
 			$this->jobList->expects(self::once())
 				->method('remove')
 				->with(BackgroundJob::class, [
 					'id' => $id,
-					'activities' => true,
+					'activities' => $hasActivity,
 					'notifications' => true,
+					'emails' => $hasEmail,
 				]);
 			$this->jobList->expects(self::once())
 				->method('add')
 				->with(BackgroundJob::class, [
 					'id' => $id,
-					'activities' => true,
+					'activities' => $hasActivity,
 					'notifications' => false,
+					'emails' => $hasEmail,
 				]);
 		} else {
 			$this->jobList->expects(self::once())
 				->method('remove')
 				->with(BackgroundJob::class, [
 					'id' => $id,
-					'activities' => false,
+					'activities' => $hasActivity,
 					'notifications' => true,
+					'emails' => $hasEmail,
 				]);
 		}
 

--- a/tests/Notification/NotifierTest.php
+++ b/tests/Notification/NotifierTest.php
@@ -150,9 +150,9 @@ class NotifierTest extends TestCase {
 	public function dataPrepare(): array {
 		$message = "message\nmessage message message message message message message message message message message messagemessagemessagemessagemessagemessagemessage";
 		return [
-			['author', 'subject', 'message', '42', null, 'author announced “subject”', 'message'],
-			['author1', 'subject', 'message', '42', $this->getUserMock(), 'Author announced “subject”', 'message'],
-			['author2', "subject\nsubject", $message, '21', null, 'author2 announced “subject subject”', $message],
+			['author', 'subject', 'message', 'message', '42', null, 'author announced “subject”', 'message'],
+			['author1', 'subject', 'message', 'message', '42', $this->getUserMock(), 'Author announced “subject”', 'message'],
+			['author2', "subject\nsubject", $message, $message, '21', null, 'author2 announced “subject subject”', $message],
 		];
 	}
 
@@ -162,12 +162,13 @@ class NotifierTest extends TestCase {
 	 * @param string $author
 	 * @param string $subject
 	 * @param string $message
+	 * @param string $plainMessage
 	 * @param int $objectId
 	 * @param \OCP\IUser $userObject
 	 * @param string $expectedSubject
 	 * @param string $expectedMessage
 	 */
-	public function testPrepare($author, $subject, $message, $objectId, $userObject, $expectedSubject, $expectedMessage): void {
+	public function testPrepare($author, $subject, $message, $plainMessage, $objectId, $userObject, $expectedSubject, $expectedMessage): void {
 		/** @var INotification|MockObject $notification */
 		$notification = $this->createMock(INotification::class);
 
@@ -187,6 +188,7 @@ class NotifierTest extends TestCase {
 		$announcement = Announcement::fromParams([
 			'subject' => $subject,
 			'message' => $message,
+			'plainMessage' => $plainMessage,
 		]);
 
 		$this->manager->expects(self::once())

--- a/tests/Settings/AdminTest.php
+++ b/tests/Settings/AdminTest.php
@@ -48,60 +48,77 @@ class AdminTest extends TestCase {
 				[
 					['announcementcenter', 'create_activities', 'yes', 'yes'],
 					['announcementcenter', 'create_notifications', 'yes', 'yes'],
+					['announcementcenter', 'send_emails', 'yes', 'yes'],
 					['announcementcenter', 'allow_comments', 'yes', 'yes'],
 					['announcementcenter', 'admin_groups', json_encode(['admin']), json_encode(['admin'])],
 				],
-				'admin', true, true, true,
+				'admin', true, true, true, true,
 			],
 			[
 				[
 					['announcementcenter', 'create_activities', 'yes', 'no'],
 					['announcementcenter', 'create_notifications', 'yes', 'yes'],
+					['announcementcenter', 'send_emails', 'yes', 'yes'],
 					['announcementcenter', 'allow_comments', 'yes', 'yes'],
 					['announcementcenter', 'admin_groups', json_encode(['admin']), json_encode(['admin'])],
 				],
-				'admin', false, true, true,
+				'admin', false, true, true, true,
 			],
 			[
 				[
 					['announcementcenter', 'create_activities', 'yes', 'yes'],
 					['announcementcenter', 'create_notifications', 'yes', 'no'],
+					['announcementcenter', 'send_emails', 'yes', 'yes'],
 					['announcementcenter', 'allow_comments', 'yes', 'yes'],
 					['announcementcenter', 'admin_groups', json_encode(['admin']), json_encode(['admin'])],
 				],
-				'admin', true, false, true,
+				'admin', true, false, true, true,
 			],
 			[
 				[
 					['announcementcenter', 'create_activities', 'yes', 'yes'],
 					['announcementcenter', 'create_notifications', 'yes', 'yes'],
+					['announcementcenter', 'send_emails', 'yes', 'no'],
+					['announcementcenter', 'allow_comments', 'yes', 'yes'],
+					['announcementcenter', 'admin_groups', json_encode(['admin']), json_encode(['admin'])],
+				],
+				'admin', true, true, false, true,
+			],
+			[
+				[
+					['announcementcenter', 'create_activities', 'yes', 'yes'],
+					['announcementcenter', 'create_notifications', 'yes', 'yes'],
+					['announcementcenter', 'send_emails', 'yes', 'yes'],
 					['announcementcenter', 'allow_comments', 'yes', 'no'],
 					['announcementcenter', 'admin_groups', json_encode(['admin']), json_encode(['admin'])],
 				],
-				'admin', true, true, false,
+				'admin', true, true, true, false,
 			],
 			[
 				[
 					['announcementcenter', 'create_activities', 'yes', 'no'],
 					['announcementcenter', 'create_notifications', 'yes', 'no'],
+					['announcementcenter', 'send_emails', 'yes', 'no'],
 					['announcementcenter', 'allow_comments', 'yes', 'no'],
 					['announcementcenter', 'admin_groups', json_encode(['admin']), json_encode(['admin', 'group2'])],
 				],
-				'admin|group2', false, false, false,
+				'admin|group2', false, false, false, false,
 			],
 		];
 	}
 
 	/**
 	 * @dataProvider dataGetForm
+	 *
 	 * @param array $configMap
 	 * @param string $adminGroups
 	 * @param bool $createActivities
 	 * @param bool $createNotifications
+	 * @param bool $sendEmails
 	 * @param bool $allowComments
 	 */
-	public function testGetForm(array $configMap, $adminGroups, $createActivities, $createNotifications, $allowComments) {
-		$this->config->expects(self::exactly(4))
+	public function testGetForm(array $configMap, $adminGroups, $createActivities, $createNotifications, $sendEmails, $allowComments) {
+		$this->config->expects(self::exactly(5))
 			->method('getAppValue')
 			->willReturnMap($configMap);
 
@@ -109,6 +126,7 @@ class AdminTest extends TestCase {
 			'adminGroups' => $adminGroups,
 			'createActivities' => $createActivities,
 			'createNotifications' => $createNotifications,
+			'sendEmails' => $sendEmails,
 			'allowComments' => $allowComments,
 		], 'blank');
 		self::assertEquals($expected, $this->admin->getForm());


### PR DESCRIPTION
This PR is based on #140. Thanks to @nickvergessen for the great
groundwork <3
    
In frontend, We use remark plugin strip-markdown to strip markdown
formatting from the message. Remark was chosen as that's the library
used by juliushaertl/vue-richtext as well.
    
The options for strip-markdown are changed to keep blockquote and
listItem formatting.
    
The stripped message is given to the backend as extra parameter
`plainMessage`.
    
The backend stores plainMessage in the DB and uses it to build the
email body.
    
Fixes: #65
    
Signed-off-by: Jonas <jonas@freesources.org>