### PR TITLE
Don't load comment sidebar when the active announcement doesn't allow comments

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -41,7 +41,7 @@
 				</template>
 			</NcEmptyContent>
 		</NcAppContent>
-		<NcAppSidebar v-if="activeId !== 0"
+		<NcAppSidebar v-show="activeId !== 0 && activateAnnouncementHasComments"
 			:title="activeAnnouncementTitle + ' - ' + t('announcementcenter', 'Comments')"
 			@close="onClickAnnouncement(0)">
 			<div ref="sidebar"
@@ -98,14 +98,18 @@ export default {
 			}
 			return this.activeAnnouncement?.subject
 		},
+
+		activateAnnouncementHasComments() {
+			return this.activeAnnouncement?.comments === 0 || this.activeAnnouncement?.comments > 0
+		},
 	},
 
-	mounted() {
-		this.loadAnnouncements()
+	async mounted() {
+		await this.loadAnnouncements()
 
 		const activeId = loadState('announcementcenter', 'activeId', 0)
 		if (activeId !== 0) {
-			this.onClickAnnouncement(activeId)
+			await this.onClickAnnouncement(activeId)
 		}
 	},
 
@@ -130,6 +134,10 @@ export default {
 			}
 
 			this.activeId = id
+
+			if (!this.activateAnnouncementHasComments) {
+				return
+			}
 
 			if (id === 0) {
 				// Destroy the comments view as the sidebar is destroyed


### PR DESCRIPTION
When linked to directly though `/?announcement=1`, the sidebar always opened and showed an error telling that loading comments is impossible.
On backend this gives a sabre exception: « Entity does not exist or is not available », so we want to avoid to make that call.

A drawback is that we now have to wait for the full announcement list to be loaded before loading the comment sidebar.

Similar to #364