### PR TITLE
Release for 26

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,21 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## 6.5.0 – 2023-02-16
+### Added
+- Compatibility with Nextcloud 26
+
+### Changed
+- Updated and migrated some dependencies
+
+### Fixed
+- Don't load comment sidebar when the active announcement doesn't allow comments
+  [#576](https://github.com/nextcloud/announcementcenter/pull/576)
+- Log announcement creation and deletion
+  [#571](https://github.com/nextcloud/announcementcenter/pull/571)
+- Skip users without a valid email address
+  [#551](https://github.com/nextcloud/announcementcenter/pull/551)
+
 ## 6.4.0 – 2022-10-18
 ### Changed
 - Compatibility with Nextcloud 25

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -17,7 +17,7 @@
 ⚡ Activities integration
 
 🔔 Notifications integration]]></description>
-	<version>6.4.0</version>
+	<version>6.5.0</version>
 	<licence>agpl</licence>
 	<author>Joas Schilling</author>
 	<namespace>AnnouncementCenter</namespace>
@@ -35,7 +35,7 @@
 	<screenshot>https://github.com/nextcloud/announcementcenter/raw/master/docs/AnnouncementCenterFrontpage.png</screenshot>
 
 	<dependencies>
-		<nextcloud min-version="25" max-version="25" />
+		<nextcloud min-version="25" max-version="26" />
 	</dependencies>
 
 	<repair-steps>

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,6 @@
 			"version": "6.1.1",
 			"license": "agpl",
 			"dependencies": {
-				"@juliushaertl/vue-richtext": "^1.0.1",
 				"@nextcloud/auth": "^2.0.0",
 				"@nextcloud/axios": "^2.3.0",
 				"@nextcloud/dialogs": "^3.2.0",
@@ -18,6 +17,7 @@
 				"@nextcloud/moment": "^1.2.1",
 				"@nextcloud/router": "^2.0.1",
 				"@nextcloud/vue": "^7.6.0",
+				"@nextcloud/vue-richtext": "^2.1.0-beta.5",
 				"debounce": "^1.2.1",
 				"remark": "^14.0.2",
 				"strip-markdown": "^5.0.0",
@@ -2730,72 +2730,12 @@
 				"@jridgewell/sourcemap-codec": "^1.4.10"
 			}
 		},
-		"node_modules/@juliushaertl/vue-richtext": {
-			"version": "1.0.1",
-			"license": "AGPL-3.0",
-			"dependencies": {
-				"clone": "^2.1.2",
-				"core-js": "^3.6.4",
-				"property-information": "^5.5.0",
-				"rehype-add-classes": "^1.0.0",
-				"rehype-react": "^6.1.0",
-				"remark-breaks": "2.0.0",
-				"remark-disable-tokenizers": "^1.0.0",
-				"remark-external-links": "^8.0.0",
-				"remark-parse": "^8.0.3",
-				"remark-rehype": "^8.0.0 ",
-				"unified": "^9.2.0",
-				"vue": "^2.6.12"
-			},
-			"engines": {
-				"node": ">=10.0.0"
-			},
-			"peerDependencies": {
-				"vue": "^2.6.11"
-			}
-		},
-		"node_modules/@juliushaertl/vue-richtext/node_modules/remark-parse": {
-			"version": "8.0.3",
-			"license": "MIT",
-			"dependencies": {
-				"ccount": "^1.0.0",
-				"collapse-white-space": "^1.0.2",
-				"is-alphabetical": "^1.0.0",
-				"is-decimal": "^1.0.0",
-				"is-whitespace-character": "^1.0.0",
-				"is-word-character": "^1.0.0",
-				"markdown-escapes": "^1.0.0",
-				"parse-entities": "^2.0.0",
-				"repeat-string": "^1.5.4",
-				"state-toggle": "^1.0.0",
-				"trim": "0.0.1",
-				"trim-trailing-lines": "^1.0.0",
-				"unherit": "^1.0.4",
-				"unist-util-remove-position": "^2.0.0",
-				"vfile-location": "^3.0.0",
-				"xtend": "^4.0.1"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/unified"
-			}
-		},
 		"node_modules/@leichtgewicht/ip-codec": {
 			"version": "2.0.4",
 			"resolved": "https://registry.npmjs.org/@leichtgewicht/ip-codec/-/ip-codec-2.0.4.tgz",
 			"integrity": "sha512-Hcv+nVC0kZnQ3tD9GVu5xSMR4VVYOteQIr/hwFPVEvPdlXqgGEuRjiheChHgdM+JyqdgNcmzZOX/tnl0JOiI7A==",
 			"dev": true,
 			"peer": true
-		},
-		"node_modules/@mapbox/hast-util-table-cell-style": {
-			"version": "0.1.3",
-			"license": "BSD-2-Clause",
-			"dependencies": {
-				"unist-util-visit": "^1.3.0"
-			},
-			"engines": {
-				"node": ">=4"
-			}
 		},
 		"node_modules/@nextcloud/auth": {
 			"version": "2.0.0",
@@ -3103,6 +3043,40 @@
 				"vue-material-design-icons": "^5.1.2",
 				"vue-multiselect": "^2.1.6",
 				"vue2-datepicker": "^3.11.0"
+			},
+			"engines": {
+				"node": "^16.0.0",
+				"npm": "^7.0.0 || ^8.0.0"
+			}
+		},
+		"node_modules/@nextcloud/vue-richtext": {
+			"version": "2.1.0-beta.5",
+			"resolved": "https://registry.npmjs.org/@nextcloud/vue-richtext/-/vue-richtext-2.1.0-beta.5.tgz",
+			"integrity": "sha512-ivvP5AfjyQyhvqfFjJGkjwWFHtur3YaRHwatTYu0BWL3wDKoX9S1I6tb/GQphXB5jabMCTmdi7sPywAs9rwH4Q==",
+			"dependencies": {
+				"@nextcloud/axios": "^2.0.0",
+				"@nextcloud/event-bus": "^3.0.2",
+				"@nextcloud/initial-state": "^2.0.0",
+				"@nextcloud/router": "^2.0.0",
+				"@nextcloud/vue": "^7.5.0",
+				"clone": "^2.1.2",
+				"vue": "^2.7.8",
+				"vue-material-design-icons": "^5.1.2"
+			},
+			"engines": {
+				"node": ">=14.0.0",
+				"npm": ">=7.0.0"
+			},
+			"peerDependencies": {
+				"vue": "^2.7.8"
+			}
+		},
+		"node_modules/@nextcloud/vue-richtext/node_modules/@nextcloud/event-bus": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/@nextcloud/event-bus/-/event-bus-3.0.2.tgz",
+			"integrity": "sha512-svXCZa4UkoZKsBiGzTi0cVcbPFUOhCm7pMKjGumRwBvHywX+8by478IQ8Grw75PFHxajMJZ0KrOTTM8WnzzEAw==",
+			"dependencies": {
+				"semver": "^7.3.7"
 			},
 			"engines": {
 				"node": "^16.0.0",
@@ -4509,14 +4483,6 @@
 				"@babel/core": "^7.0.0-0"
 			}
 		},
-		"node_modules/bail": {
-			"version": "1.0.5",
-			"license": "MIT",
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/sponsors/wooorm"
-			}
-		},
 		"node_modules/balanced-match": {
 			"version": "1.0.0",
 			"dev": true,
@@ -4634,7 +4600,9 @@
 		},
 		"node_modules/boolbase": {
 			"version": "1.0.0",
-			"license": "ISC"
+			"dev": true,
+			"license": "ISC",
+			"peer": true
 		},
 		"node_modules/brace-expansion": {
 			"version": "1.1.11",
@@ -4929,14 +4897,6 @@
 			],
 			"peer": true
 		},
-		"node_modules/ccount": {
-			"version": "1.1.0",
-			"license": "MIT",
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/sponsors/wooorm"
-			}
-		},
 		"node_modules/chalk": {
 			"version": "2.4.2",
 			"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
@@ -4958,30 +4918,6 @@
 			"integrity": "sha512-oGu2QekBMXgyQNWPDRQ001bjvDnZe4/zBTz37TMbiKz1NbNiyiH5hRkobe7npRN6GfbGbxMYFck/vQ1r9c1VMA==",
 			"engines": {
 				"node": ">=12.20"
-			}
-		},
-		"node_modules/character-entities": {
-			"version": "1.2.4",
-			"license": "MIT",
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/sponsors/wooorm"
-			}
-		},
-		"node_modules/character-entities-legacy": {
-			"version": "1.1.4",
-			"license": "MIT",
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/sponsors/wooorm"
-			}
-		},
-		"node_modules/character-reference-invalid": {
-			"version": "1.1.4",
-			"license": "MIT",
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/sponsors/wooorm"
 			}
 		},
 		"node_modules/charenc": {
@@ -5065,14 +5001,6 @@
 				"node": ">=6"
 			}
 		},
-		"node_modules/collapse-white-space": {
-			"version": "1.0.6",
-			"license": "MIT",
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/sponsors/wooorm"
-			}
-		},
 		"node_modules/color-convert": {
 			"version": "1.9.3",
 			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
@@ -5113,14 +5041,6 @@
 			},
 			"engines": {
 				"node": ">= 0.8"
-			}
-		},
-		"node_modules/comma-separated-tokens": {
-			"version": "1.0.8",
-			"license": "MIT",
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/sponsors/wooorm"
 			}
 		},
 		"node_modules/commander": {
@@ -5499,10 +5419,6 @@
 			"peerDependencies": {
 				"webpack": "^5.0.0"
 			}
-		},
-		"node_modules/css-selector-parser": {
-			"version": "1.4.1",
-			"license": "MIT"
 		},
 		"node_modules/cssesc": {
 			"version": "3.0.0",
@@ -7623,75 +7539,6 @@
 				"minimalistic-assert": "^1.0.1"
 			}
 		},
-		"node_modules/hast-to-hyperscript": {
-			"version": "9.0.1",
-			"license": "MIT",
-			"dependencies": {
-				"@types/unist": "^2.0.3",
-				"comma-separated-tokens": "^1.0.0",
-				"property-information": "^5.3.0",
-				"space-separated-tokens": "^1.0.0",
-				"style-to-object": "^0.3.0",
-				"unist-util-is": "^4.0.0",
-				"web-namespaces": "^1.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/unified"
-			}
-		},
-		"node_modules/hast-util-has-property": {
-			"version": "1.0.4",
-			"license": "MIT",
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/unified"
-			}
-		},
-		"node_modules/hast-util-is-element": {
-			"version": "1.1.0",
-			"license": "MIT",
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/unified"
-			}
-		},
-		"node_modules/hast-util-select": {
-			"version": "1.0.1",
-			"license": "MIT",
-			"dependencies": {
-				"camelcase": "^3.0.0",
-				"comma-separated-tokens": "^1.0.2",
-				"css-selector-parser": "^1.3.0",
-				"hast-util-has-property": "^1.0.0",
-				"hast-util-is-element": "^1.0.0",
-				"hast-util-whitespace": "^1.0.0",
-				"not": "^0.1.0",
-				"nth-check": "^1.0.1",
-				"property-information": "^3.1.0",
-				"space-separated-tokens": "^1.1.0",
-				"zwitch": "^1.0.0"
-			}
-		},
-		"node_modules/hast-util-select/node_modules/camelcase": {
-			"version": "3.0.0",
-			"license": "MIT",
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/hast-util-select/node_modules/property-information": {
-			"version": "3.2.0",
-			"license": "MIT"
-		},
-		"node_modules/hast-util-whitespace": {
-			"version": "1.0.4",
-			"license": "MIT",
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/unified"
-			}
-		},
 		"node_modules/he": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
@@ -8032,7 +7879,9 @@
 		},
 		"node_modules/inherits": {
 			"version": "2.0.4",
-			"license": "ISC"
+			"dev": true,
+			"license": "ISC",
+			"peer": true
 		},
 		"node_modules/ini": {
 			"version": "1.3.8",
@@ -8040,10 +7889,6 @@
 			"integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
 			"dev": true,
 			"peer": true
-		},
-		"node_modules/inline-style-parser": {
-			"version": "0.1.1",
-			"license": "MIT"
 		},
 		"node_modules/internal-slot": {
 			"version": "1.0.3",
@@ -8078,33 +7923,6 @@
 			"peer": true,
 			"engines": {
 				"node": ">= 10"
-			}
-		},
-		"node_modules/is-absolute-url": {
-			"version": "3.0.3",
-			"license": "MIT",
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/is-alphabetical": {
-			"version": "1.0.4",
-			"license": "MIT",
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/sponsors/wooorm"
-			}
-		},
-		"node_modules/is-alphanumerical": {
-			"version": "1.0.4",
-			"license": "MIT",
-			"dependencies": {
-				"is-alphabetical": "^1.0.0",
-				"is-decimal": "^1.0.0"
-			},
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/sponsors/wooorm"
 			}
 		},
 		"node_modules/is-arguments": {
@@ -8217,14 +8035,6 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
-		"node_modules/is-decimal": {
-			"version": "1.0.4",
-			"license": "MIT",
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/sponsors/wooorm"
-			}
-		},
 		"node_modules/is-docker": {
 			"version": "2.2.1",
 			"resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
@@ -8289,14 +8099,6 @@
 				"node": ">=0.10.0"
 			}
 		},
-		"node_modules/is-hexadecimal": {
-			"version": "1.0.4",
-			"license": "MIT",
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/sponsors/wooorm"
-			}
-		},
 		"node_modules/is-nan": {
 			"version": "1.3.2",
 			"resolved": "https://registry.npmjs.org/is-nan/-/is-nan-1.3.2.tgz",
@@ -8359,13 +8161,6 @@
 			"integrity": "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==",
 			"dev": true,
 			"peer": true,
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/is-plain-obj": {
-			"version": "2.1.0",
-			"license": "MIT",
 			"engines": {
 				"node": ">=8"
 			}
@@ -8503,22 +8298,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/is-whitespace-character": {
-			"version": "1.0.4",
-			"license": "MIT",
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/sponsors/wooorm"
-			}
-		},
-		"node_modules/is-word-character": {
-			"version": "1.0.4",
-			"license": "MIT",
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/sponsors/wooorm"
 			}
 		},
 		"node_modules/is-wsl": {
@@ -8886,14 +8665,6 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/markdown-escapes": {
-			"version": "1.0.4",
-			"license": "MIT",
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/sponsors/wooorm"
-			}
-		},
 		"node_modules/material-colors": {
 			"version": "1.2.6",
 			"license": "ISC"
@@ -8930,42 +8701,6 @@
 				"safe-buffer": "^5.1.2"
 			}
 		},
-		"node_modules/mdast-util-definitions": {
-			"version": "4.0.0",
-			"license": "MIT",
-			"dependencies": {
-				"unist-util-visit": "^2.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/unified"
-			}
-		},
-		"node_modules/mdast-util-definitions/node_modules/unist-util-visit": {
-			"version": "2.0.3",
-			"license": "MIT",
-			"dependencies": {
-				"@types/unist": "^2.0.0",
-				"unist-util-is": "^4.0.0",
-				"unist-util-visit-parents": "^3.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/unified"
-			}
-		},
-		"node_modules/mdast-util-definitions/node_modules/unist-util-visit-parents": {
-			"version": "3.1.1",
-			"license": "MIT",
-			"dependencies": {
-				"@types/unist": "^2.0.0",
-				"unist-util-is": "^4.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/unified"
-			}
-		},
 		"node_modules/mdast-util-from-markdown": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-1.2.0.tgz",
@@ -8995,49 +8730,6 @@
 			"integrity": "sha512-7A6eiDCs9UtjcwZOcCpM4aPII3bAAGv13E96IkawkOAW0OhH+yRxtY0lzo8KiHpzEMfH7Q+FizUmwp8Iqy5EWg==",
 			"dependencies": {
 				"@types/unist": "^2.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/unified"
-			}
-		},
-		"node_modules/mdast-util-to-hast": {
-			"version": "10.1.1",
-			"license": "MIT",
-			"dependencies": {
-				"@types/mdast": "^3.0.0",
-				"@types/unist": "^2.0.0",
-				"mdast-util-definitions": "^4.0.0",
-				"mdurl": "^1.0.0",
-				"unist-builder": "^2.0.0",
-				"unist-util-generated": "^1.0.0",
-				"unist-util-position": "^3.0.0",
-				"unist-util-visit": "^2.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/unified"
-			}
-		},
-		"node_modules/mdast-util-to-hast/node_modules/unist-util-visit": {
-			"version": "2.0.3",
-			"license": "MIT",
-			"dependencies": {
-				"@types/unist": "^2.0.0",
-				"unist-util-is": "^4.0.0",
-				"unist-util-visit-parents": "^3.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/unified"
-			}
-		},
-		"node_modules/mdast-util-to-hast/node_modules/unist-util-visit-parents": {
-			"version": "3.1.1",
-			"license": "MIT",
-			"dependencies": {
-				"@types/unist": "^2.0.0",
-				"unist-util-is": "^4.0.0"
 			},
 			"funding": {
 				"type": "opencollective",
@@ -9115,10 +8807,6 @@
 				"type": "opencollective",
 				"url": "https://opencollective.com/unified"
 			}
-		},
-		"node_modules/mdurl": {
-			"version": "1.0.1",
-			"license": "MIT"
 		},
 		"node_modules/media-typer": {
 			"version": "0.3.0",
@@ -10226,9 +9914,6 @@
 				"node": ">=0.10.0"
 			}
 		},
-		"node_modules/not": {
-			"version": "0.1.0"
-		},
 		"node_modules/npm-run-path": {
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
@@ -10240,13 +9925,6 @@
 			},
 			"engines": {
 				"node": ">=8"
-			}
-		},
-		"node_modules/nth-check": {
-			"version": "1.0.2",
-			"license": "BSD-2-Clause",
-			"dependencies": {
-				"boolbase": "~1.0.0"
 			}
 		},
 		"node_modules/object-inspect": {
@@ -10507,22 +10185,6 @@
 				"evp_bytestokey": "^1.0.0",
 				"pbkdf2": "^3.0.3",
 				"safe-buffer": "^5.1.1"
-			}
-		},
-		"node_modules/parse-entities": {
-			"version": "2.0.0",
-			"license": "MIT",
-			"dependencies": {
-				"character-entities": "^1.0.0",
-				"character-entities-legacy": "^1.0.0",
-				"character-reference-invalid": "^1.0.0",
-				"is-alphanumerical": "^1.0.0",
-				"is-decimal": "^1.0.0",
-				"is-hexadecimal": "^1.0.0"
-			},
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/sponsors/wooorm"
 			}
 		},
 		"node_modules/parseurl": {
@@ -10896,17 +10558,6 @@
 			"dev": true,
 			"peer": true
 		},
-		"node_modules/property-information": {
-			"version": "5.6.0",
-			"license": "MIT",
-			"dependencies": {
-				"xtend": "^4.0.0"
-			},
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/sponsors/wooorm"
-			}
-		},
 		"node_modules/proxy-addr": {
 			"version": "2.0.7",
 			"resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
@@ -11253,25 +10904,6 @@
 				"jsesc": "bin/jsesc"
 			}
 		},
-		"node_modules/rehype-add-classes": {
-			"version": "1.0.0",
-			"license": "MIT",
-			"dependencies": {
-				"hast-util-select": "^1.0.1"
-			}
-		},
-		"node_modules/rehype-react": {
-			"version": "6.2.0",
-			"license": "MIT",
-			"dependencies": {
-				"@mapbox/hast-util-table-cell-style": "^0.1.3",
-				"hast-to-hyperscript": "^9.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/unified"
-			}
-		},
 		"node_modules/remark": {
 			"version": "14.0.2",
 			"resolved": "https://registry.npmjs.org/remark/-/remark-14.0.2.tgz",
@@ -11281,64 +10913,6 @@
 				"remark-parse": "^10.0.0",
 				"remark-stringify": "^10.0.0",
 				"unified": "^10.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/unified"
-			}
-		},
-		"node_modules/remark-breaks": {
-			"version": "2.0.0",
-			"license": "MIT",
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/unified"
-			}
-		},
-		"node_modules/remark-disable-tokenizers": {
-			"version": "1.0.24",
-			"license": "MIT",
-			"dependencies": {
-				"clone": "^2.1.2"
-			},
-			"engines": {
-				"node": ">=4"
-			}
-		},
-		"node_modules/remark-external-links": {
-			"version": "8.0.0",
-			"license": "MIT",
-			"dependencies": {
-				"extend": "^3.0.0",
-				"is-absolute-url": "^3.0.0",
-				"mdast-util-definitions": "^4.0.0",
-				"space-separated-tokens": "^1.0.0",
-				"unist-util-visit": "^2.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/unified"
-			}
-		},
-		"node_modules/remark-external-links/node_modules/unist-util-visit": {
-			"version": "2.0.3",
-			"license": "MIT",
-			"dependencies": {
-				"@types/unist": "^2.0.0",
-				"unist-util-is": "^4.0.0",
-				"unist-util-visit-parents": "^3.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/unified"
-			}
-		},
-		"node_modules/remark-external-links/node_modules/unist-util-visit-parents": {
-			"version": "3.1.1",
-			"license": "MIT",
-			"dependencies": {
-				"@types/unist": "^2.0.0",
-				"unist-util-is": "^4.0.0"
 			},
 			"funding": {
 				"type": "opencollective",
@@ -11462,17 +11036,6 @@
 			"dependencies": {
 				"@types/unist": "^2.0.0",
 				"unist-util-stringify-position": "^3.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/unified"
-			}
-		},
-		"node_modules/remark-rehype": {
-			"version": "8.0.0",
-			"license": "MIT",
-			"dependencies": {
-				"mdast-util-to-hast": "^10.0.0"
 			},
 			"funding": {
 				"type": "opencollective",
@@ -11709,13 +11272,6 @@
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/unified"
-			}
-		},
-		"node_modules/repeat-string": {
-			"version": "1.6.1",
-			"license": "MIT",
-			"engines": {
-				"node": ">=0.10"
 			}
 		},
 		"node_modules/require-from-string": {
@@ -12343,14 +11899,6 @@
 				"source-map": "^0.6.0"
 			}
 		},
-		"node_modules/space-separated-tokens": {
-			"version": "1.1.5",
-			"license": "MIT",
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/sponsors/wooorm"
-			}
-		},
 		"node_modules/spdx-correct": {
 			"version": "3.1.1",
 			"resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.1.tgz",
@@ -12473,14 +12021,6 @@
 			"version": "2.4.1",
 			"resolved": "https://registry.npmjs.org/splitpanes/-/splitpanes-2.4.1.tgz",
 			"integrity": "sha512-kpEo1WuMXuc6QfdQdO2V/fl/trONlkUKp+pputsLTiW9RMtwEvjb4/aYGm2m3+KAzjmb+zLwr4A4SYZu74+pgQ=="
-		},
-		"node_modules/state-toggle": {
-			"version": "1.0.3",
-			"license": "MIT",
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/sponsors/wooorm"
-			}
 		},
 		"node_modules/statuses": {
 			"version": "2.0.1",
@@ -12825,13 +12365,6 @@
 			"integrity": "sha1-eVjHk+R+MuB9K1yv5cC/jhLneQI=",
 			"dev": true,
 			"peer": true
-		},
-		"node_modules/style-to-object": {
-			"version": "0.3.0",
-			"license": "MIT",
-			"dependencies": {
-				"inline-style-parser": "0.1.1"
-			}
 		},
 		"node_modules/stylelint": {
 			"version": "14.10.0",
@@ -13336,9 +12869,6 @@
 			"version": "5.1.3",
 			"license": "MIT"
 		},
-		"node_modules/trim": {
-			"version": "0.0.1"
-		},
 		"node_modules/trim-newlines": {
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-3.0.1.tgz",
@@ -13347,22 +12877,6 @@
 			"peer": true,
 			"engines": {
 				"node": ">=8"
-			}
-		},
-		"node_modules/trim-trailing-lines": {
-			"version": "1.1.4",
-			"license": "MIT",
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/sponsors/wooorm"
-			}
-		},
-		"node_modules/trough": {
-			"version": "1.0.5",
-			"license": "MIT",
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/sponsors/wooorm"
 			}
 		},
 		"node_modules/tsconfig-paths": {
@@ -13496,18 +13010,6 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
-		"node_modules/unherit": {
-			"version": "1.1.3",
-			"license": "MIT",
-			"dependencies": {
-				"inherits": "^2.0.0",
-				"xtend": "^4.0.0"
-			},
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/sponsors/wooorm"
-			}
-		},
 		"node_modules/unicode-canonical-property-names-ecmascript": {
 			"version": "1.0.4",
 			"dev": true,
@@ -13547,140 +13049,6 @@
 			"engines": {
 				"node": ">=4"
 			}
-		},
-		"node_modules/unified": {
-			"version": "9.2.0",
-			"license": "MIT",
-			"dependencies": {
-				"bail": "^1.0.0",
-				"extend": "^3.0.0",
-				"is-buffer": "^2.0.0",
-				"is-plain-obj": "^2.0.0",
-				"trough": "^1.0.0",
-				"vfile": "^4.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/unified"
-			}
-		},
-		"node_modules/unified/node_modules/is-buffer": {
-			"version": "2.0.5",
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/feross"
-				},
-				{
-					"type": "patreon",
-					"url": "https://www.patreon.com/feross"
-				},
-				{
-					"type": "consulting",
-					"url": "https://feross.org/support"
-				}
-			],
-			"license": "MIT",
-			"engines": {
-				"node": ">=4"
-			}
-		},
-		"node_modules/unist-builder": {
-			"version": "2.0.3",
-			"license": "MIT",
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/unified"
-			}
-		},
-		"node_modules/unist-util-generated": {
-			"version": "1.1.6",
-			"license": "MIT",
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/unified"
-			}
-		},
-		"node_modules/unist-util-is": {
-			"version": "4.0.4",
-			"license": "MIT",
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/unified"
-			}
-		},
-		"node_modules/unist-util-position": {
-			"version": "3.1.0",
-			"license": "MIT",
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/unified"
-			}
-		},
-		"node_modules/unist-util-remove-position": {
-			"version": "2.0.1",
-			"license": "MIT",
-			"dependencies": {
-				"unist-util-visit": "^2.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/unified"
-			}
-		},
-		"node_modules/unist-util-remove-position/node_modules/unist-util-visit": {
-			"version": "2.0.3",
-			"license": "MIT",
-			"dependencies": {
-				"@types/unist": "^2.0.0",
-				"unist-util-is": "^4.0.0",
-				"unist-util-visit-parents": "^3.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/unified"
-			}
-		},
-		"node_modules/unist-util-remove-position/node_modules/unist-util-visit-parents": {
-			"version": "3.1.1",
-			"license": "MIT",
-			"dependencies": {
-				"@types/unist": "^2.0.0",
-				"unist-util-is": "^4.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/unified"
-			}
-		},
-		"node_modules/unist-util-stringify-position": {
-			"version": "2.0.3",
-			"license": "MIT",
-			"dependencies": {
-				"@types/unist": "^2.0.2"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/unified"
-			}
-		},
-		"node_modules/unist-util-visit": {
-			"version": "1.4.1",
-			"license": "MIT",
-			"dependencies": {
-				"unist-util-visit-parents": "^2.0.0"
-			}
-		},
-		"node_modules/unist-util-visit-parents": {
-			"version": "2.1.2",
-			"license": "MIT",
-			"dependencies": {
-				"unist-util-is": "^3.0.0"
-			}
-		},
-		"node_modules/unist-util-visit-parents/node_modules/unist-util-is": {
-			"version": "3.0.0",
-			"license": "MIT"
 		},
 		"node_modules/unpipe": {
 			"version": "1.0.0",
@@ -13837,61 +13205,6 @@
 			"peer": true,
 			"engines": {
 				"node": ">= 0.8"
-			}
-		},
-		"node_modules/vfile": {
-			"version": "4.2.1",
-			"license": "MIT",
-			"dependencies": {
-				"@types/unist": "^2.0.0",
-				"is-buffer": "^2.0.0",
-				"unist-util-stringify-position": "^2.0.0",
-				"vfile-message": "^2.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/unified"
-			}
-		},
-		"node_modules/vfile-location": {
-			"version": "3.2.0",
-			"license": "MIT",
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/unified"
-			}
-		},
-		"node_modules/vfile-message": {
-			"version": "2.0.4",
-			"license": "MIT",
-			"dependencies": {
-				"@types/unist": "^2.0.0",
-				"unist-util-stringify-position": "^2.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/unified"
-			}
-		},
-		"node_modules/vfile/node_modules/is-buffer": {
-			"version": "2.0.5",
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/feross"
-				},
-				{
-					"type": "patreon",
-					"url": "https://www.patreon.com/feross"
-				},
-				{
-					"type": "consulting",
-					"url": "https://feross.org/support"
-				}
-			],
-			"license": "MIT",
-			"engines": {
-				"node": ">=4"
 			}
 		},
 		"node_modules/vm-browserify": {
@@ -14174,14 +13487,6 @@
 			"peer": true,
 			"dependencies": {
 				"minimalistic-assert": "^1.0.0"
-			}
-		},
-		"node_modules/web-namespaces": {
-			"version": "1.1.4",
-			"license": "MIT",
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/sponsors/wooorm"
 			}
 		},
 		"node_modules/webpack": {
@@ -14677,7 +13982,9 @@
 		},
 		"node_modules/xtend": {
 			"version": "4.0.2",
+			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": ">=0.4"
 			}
@@ -14719,14 +14026,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/zwitch": {
-			"version": "1.0.5",
-			"license": "MIT",
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/sponsors/wooorm"
 			}
 		}
 	},
@@ -16589,58 +15888,12 @@
 				"@jridgewell/sourcemap-codec": "^1.4.10"
 			}
 		},
-		"@juliushaertl/vue-richtext": {
-			"version": "1.0.1",
-			"requires": {
-				"clone": "^2.1.2",
-				"core-js": "^3.6.4",
-				"property-information": "^5.5.0",
-				"rehype-add-classes": "^1.0.0",
-				"rehype-react": "^6.1.0",
-				"remark-breaks": "2.0.0",
-				"remark-disable-tokenizers": "^1.0.0",
-				"remark-external-links": "^8.0.0",
-				"remark-parse": "^8.0.3",
-				"remark-rehype": "^8.0.0 ",
-				"unified": "^9.2.0",
-				"vue": "^2.6.12"
-			},
-			"dependencies": {
-				"remark-parse": {
-					"version": "8.0.3",
-					"requires": {
-						"ccount": "^1.0.0",
-						"collapse-white-space": "^1.0.2",
-						"is-alphabetical": "^1.0.0",
-						"is-decimal": "^1.0.0",
-						"is-whitespace-character": "^1.0.0",
-						"is-word-character": "^1.0.0",
-						"markdown-escapes": "^1.0.0",
-						"parse-entities": "^2.0.0",
-						"repeat-string": "^1.5.4",
-						"state-toggle": "^1.0.0",
-						"trim": "0.0.1",
-						"trim-trailing-lines": "^1.0.0",
-						"unherit": "^1.0.4",
-						"unist-util-remove-position": "^2.0.0",
-						"vfile-location": "^3.0.0",
-						"xtend": "^4.0.1"
-					}
-				}
-			}
-		},
 		"@leichtgewicht/ip-codec": {
 			"version": "2.0.4",
 			"resolved": "https://registry.npmjs.org/@leichtgewicht/ip-codec/-/ip-codec-2.0.4.tgz",
 			"integrity": "sha512-Hcv+nVC0kZnQ3tD9GVu5xSMR4VVYOteQIr/hwFPVEvPdlXqgGEuRjiheChHgdM+JyqdgNcmzZOX/tnl0JOiI7A==",
 			"dev": true,
 			"peer": true
-		},
-		"@mapbox/hast-util-table-cell-style": {
-			"version": "0.1.3",
-			"requires": {
-				"unist-util-visit": "^1.3.0"
-			}
 		},
 		"@nextcloud/auth": {
 			"version": "2.0.0",
@@ -16953,6 +16206,31 @@
 					"requires": {
 						"@babel/runtime": "^7.18.6",
 						"core-js": "^3.23.5"
+					}
+				}
+			}
+		},
+		"@nextcloud/vue-richtext": {
+			"version": "2.1.0-beta.5",
+			"resolved": "https://registry.npmjs.org/@nextcloud/vue-richtext/-/vue-richtext-2.1.0-beta.5.tgz",
+			"integrity": "sha512-ivvP5AfjyQyhvqfFjJGkjwWFHtur3YaRHwatTYu0BWL3wDKoX9S1I6tb/GQphXB5jabMCTmdi7sPywAs9rwH4Q==",
+			"requires": {
+				"@nextcloud/axios": "^2.0.0",
+				"@nextcloud/event-bus": "^3.0.2",
+				"@nextcloud/initial-state": "^2.0.0",
+				"@nextcloud/router": "^2.0.0",
+				"@nextcloud/vue": "^7.5.0",
+				"clone": "^2.1.2",
+				"vue": "^2.7.8",
+				"vue-material-design-icons": "^5.1.2"
+			},
+			"dependencies": {
+				"@nextcloud/event-bus": {
+					"version": "3.0.2",
+					"resolved": "https://registry.npmjs.org/@nextcloud/event-bus/-/event-bus-3.0.2.tgz",
+					"integrity": "sha512-svXCZa4UkoZKsBiGzTi0cVcbPFUOhCm7pMKjGumRwBvHywX+8by478IQ8Grw75PFHxajMJZ0KrOTTM8WnzzEAw==",
+					"requires": {
+						"semver": "^7.3.7"
 					}
 				}
 			}
@@ -17996,9 +17274,6 @@
 				"@babel/helper-define-polyfill-provider": "^0.2.2"
 			}
 		},
-		"bail": {
-			"version": "1.0.5"
-		},
 		"balanced-match": {
 			"version": "1.0.0",
 			"dev": true,
@@ -18088,7 +17363,9 @@
 			}
 		},
 		"boolbase": {
-			"version": "1.0.0"
+			"version": "1.0.0",
+			"dev": true,
+			"peer": true
 		},
 		"brace-expansion": {
 			"version": "1.1.11",
@@ -18310,9 +17587,6 @@
 			"dev": true,
 			"peer": true
 		},
-		"ccount": {
-			"version": "1.1.0"
-		},
 		"chalk": {
 			"version": "2.4.2",
 			"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
@@ -18329,15 +17603,6 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/char-regex/-/char-regex-2.0.0.tgz",
 			"integrity": "sha512-oGu2QekBMXgyQNWPDRQ001bjvDnZe4/zBTz37TMbiKz1NbNiyiH5hRkobe7npRN6GfbGbxMYFck/vQ1r9c1VMA=="
-		},
-		"character-entities": {
-			"version": "1.2.4"
-		},
-		"character-entities-legacy": {
-			"version": "1.1.4"
-		},
-		"character-reference-invalid": {
-			"version": "1.1.4"
 		},
 		"charenc": {
 			"version": "0.0.2"
@@ -18393,9 +17658,6 @@
 				"shallow-clone": "^3.0.0"
 			}
 		},
-		"collapse-white-space": {
-			"version": "1.0.6"
-		},
 		"color-convert": {
 			"version": "1.9.3",
 			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
@@ -18434,9 +17696,6 @@
 			"requires": {
 				"delayed-stream": "~1.0.0"
 			}
-		},
-		"comma-separated-tokens": {
-			"version": "1.0.8"
 		},
 		"commander": {
 			"version": "7.2.0",
@@ -18733,9 +17992,6 @@
 				"postcss-value-parser": "^4.2.0",
 				"semver": "^7.3.5"
 			}
-		},
-		"css-selector-parser": {
-			"version": "1.4.1"
 		},
 		"cssesc": {
 			"version": "3.0.0",
@@ -20329,51 +19585,6 @@
 				"minimalistic-assert": "^1.0.1"
 			}
 		},
-		"hast-to-hyperscript": {
-			"version": "9.0.1",
-			"requires": {
-				"@types/unist": "^2.0.3",
-				"comma-separated-tokens": "^1.0.0",
-				"property-information": "^5.3.0",
-				"space-separated-tokens": "^1.0.0",
-				"style-to-object": "^0.3.0",
-				"unist-util-is": "^4.0.0",
-				"web-namespaces": "^1.0.0"
-			}
-		},
-		"hast-util-has-property": {
-			"version": "1.0.4"
-		},
-		"hast-util-is-element": {
-			"version": "1.1.0"
-		},
-		"hast-util-select": {
-			"version": "1.0.1",
-			"requires": {
-				"camelcase": "^3.0.0",
-				"comma-separated-tokens": "^1.0.2",
-				"css-selector-parser": "^1.3.0",
-				"hast-util-has-property": "^1.0.0",
-				"hast-util-is-element": "^1.0.0",
-				"hast-util-whitespace": "^1.0.0",
-				"not": "^0.1.0",
-				"nth-check": "^1.0.1",
-				"property-information": "^3.1.0",
-				"space-separated-tokens": "^1.1.0",
-				"zwitch": "^1.0.0"
-			},
-			"dependencies": {
-				"camelcase": {
-					"version": "3.0.0"
-				},
-				"property-information": {
-					"version": "3.2.0"
-				}
-			}
-		},
-		"hast-util-whitespace": {
-			"version": "1.0.4"
-		},
 		"he": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
@@ -20625,7 +19836,9 @@
 			}
 		},
 		"inherits": {
-			"version": "2.0.4"
+			"version": "2.0.4",
+			"dev": true,
+			"peer": true
 		},
 		"ini": {
 			"version": "1.3.8",
@@ -20633,9 +19846,6 @@
 			"integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
 			"dev": true,
 			"peer": true
-		},
-		"inline-style-parser": {
-			"version": "0.1.1"
 		},
 		"internal-slot": {
 			"version": "1.0.3",
@@ -20662,19 +19872,6 @@
 			"integrity": "sha512-1qTgH9NG+IIJ4yfKs2e6Pp1bZg8wbDbKHT21HrLIeYBTRLgMYKnMTPAuI3Lcs61nfx5h1xlXnbJtH1kX5/d/ng==",
 			"dev": true,
 			"peer": true
-		},
-		"is-absolute-url": {
-			"version": "3.0.3"
-		},
-		"is-alphabetical": {
-			"version": "1.0.4"
-		},
-		"is-alphanumerical": {
-			"version": "1.0.4",
-			"requires": {
-				"is-alphabetical": "^1.0.0",
-				"is-decimal": "^1.0.0"
-			}
 		},
 		"is-arguments": {
 			"version": "1.1.1",
@@ -20752,9 +19949,6 @@
 			"dev": true,
 			"peer": true
 		},
-		"is-decimal": {
-			"version": "1.0.4"
-		},
 		"is-docker": {
 			"version": "2.2.1",
 			"resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
@@ -20793,9 +19987,6 @@
 			"requires": {
 				"is-extglob": "^2.1.1"
 			}
-		},
-		"is-hexadecimal": {
-			"version": "1.0.4"
 		},
 		"is-nan": {
 			"version": "1.3.2",
@@ -20838,9 +20029,6 @@
 			"integrity": "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==",
 			"dev": true,
 			"peer": true
-		},
-		"is-plain-obj": {
-			"version": "2.1.0"
 		},
 		"is-plain-object": {
 			"version": "2.0.4",
@@ -20931,12 +20119,6 @@
 			"requires": {
 				"call-bind": "^1.0.2"
 			}
-		},
-		"is-whitespace-character": {
-			"version": "1.0.4"
-		},
-		"is-word-character": {
-			"version": "1.0.4"
 		},
 		"is-wsl": {
 			"version": "2.2.0",
@@ -21216,9 +20398,6 @@
 			"dev": true,
 			"peer": true
 		},
-		"markdown-escapes": {
-			"version": "1.0.4"
-		},
 		"material-colors": {
 			"version": "1.2.6"
 		},
@@ -21249,29 +20428,6 @@
 				"safe-buffer": "^5.1.2"
 			}
 		},
-		"mdast-util-definitions": {
-			"version": "4.0.0",
-			"requires": {
-				"unist-util-visit": "^2.0.0"
-			},
-			"dependencies": {
-				"unist-util-visit": {
-					"version": "2.0.3",
-					"requires": {
-						"@types/unist": "^2.0.0",
-						"unist-util-is": "^4.0.0",
-						"unist-util-visit-parents": "^3.0.0"
-					}
-				},
-				"unist-util-visit-parents": {
-					"version": "3.1.1",
-					"requires": {
-						"@types/unist": "^2.0.0",
-						"unist-util-is": "^4.0.0"
-					}
-				}
-			}
-		},
 		"mdast-util-from-markdown": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-1.2.0.tgz",
@@ -21297,36 +20453,6 @@
 					"integrity": "sha512-7A6eiDCs9UtjcwZOcCpM4aPII3bAAGv13E96IkawkOAW0OhH+yRxtY0lzo8KiHpzEMfH7Q+FizUmwp8Iqy5EWg==",
 					"requires": {
 						"@types/unist": "^2.0.0"
-					}
-				}
-			}
-		},
-		"mdast-util-to-hast": {
-			"version": "10.1.1",
-			"requires": {
-				"@types/mdast": "^3.0.0",
-				"@types/unist": "^2.0.0",
-				"mdast-util-definitions": "^4.0.0",
-				"mdurl": "^1.0.0",
-				"unist-builder": "^2.0.0",
-				"unist-util-generated": "^1.0.0",
-				"unist-util-position": "^3.0.0",
-				"unist-util-visit": "^2.0.0"
-			},
-			"dependencies": {
-				"unist-util-visit": {
-					"version": "2.0.3",
-					"requires": {
-						"@types/unist": "^2.0.0",
-						"unist-util-is": "^4.0.0",
-						"unist-util-visit-parents": "^3.0.0"
-					}
-				},
-				"unist-util-visit-parents": {
-					"version": "3.1.1",
-					"requires": {
-						"@types/unist": "^2.0.0",
-						"unist-util-is": "^4.0.0"
 					}
 				}
 			}
@@ -21380,9 +20506,6 @@
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-3.1.0.tgz",
 			"integrity": "sha512-n4Vypz/DZgwo0iMHLQL49dJzlp7YtAJP+N07MZHpjPf/5XJuHUWstviF4Mn2jEiR/GNmtnRRqnwsXExk3igfFA=="
-		},
-		"mdurl": {
-			"version": "1.0.1"
 		},
 		"media-typer": {
 			"version": "0.3.0",
@@ -22127,9 +21250,6 @@
 			"dev": true,
 			"peer": true
 		},
-		"not": {
-			"version": "0.1.0"
-		},
 		"npm-run-path": {
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
@@ -22138,12 +21258,6 @@
 			"peer": true,
 			"requires": {
 				"path-key": "^3.0.0"
-			}
-		},
-		"nth-check": {
-			"version": "1.0.2",
-			"requires": {
-				"boolbase": "~1.0.0"
 			}
 		},
 		"object-inspect": {
@@ -22335,17 +21449,6 @@
 				"evp_bytestokey": "^1.0.0",
 				"pbkdf2": "^3.0.3",
 				"safe-buffer": "^5.1.1"
-			}
-		},
-		"parse-entities": {
-			"version": "2.0.0",
-			"requires": {
-				"character-entities": "^1.0.0",
-				"character-entities-legacy": "^1.0.0",
-				"character-reference-invalid": "^1.0.0",
-				"is-alphanumerical": "^1.0.0",
-				"is-decimal": "^1.0.0",
-				"is-hexadecimal": "^1.0.0"
 			}
 		},
 		"parseurl": {
@@ -22614,12 +21717,6 @@
 			"dev": true,
 			"peer": true
 		},
-		"property-information": {
-			"version": "5.6.0",
-			"requires": {
-				"xtend": "^4.0.0"
-			}
-		},
 		"proxy-addr": {
 			"version": "2.0.7",
 			"resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
@@ -22881,19 +21978,6 @@
 				}
 			}
 		},
-		"rehype-add-classes": {
-			"version": "1.0.0",
-			"requires": {
-				"hast-util-select": "^1.0.1"
-			}
-		},
-		"rehype-react": {
-			"version": "6.2.0",
-			"requires": {
-				"@mapbox/hast-util-table-cell-style": "^0.1.3",
-				"hast-to-hyperscript": "^9.0.0"
-			}
-		},
 		"remark": {
 			"version": "14.0.2",
 			"resolved": "https://registry.npmjs.org/remark/-/remark-14.0.2.tgz",
@@ -22965,42 +22049,6 @@
 					"requires": {
 						"@types/unist": "^2.0.0",
 						"unist-util-stringify-position": "^3.0.0"
-					}
-				}
-			}
-		},
-		"remark-breaks": {
-			"version": "2.0.0"
-		},
-		"remark-disable-tokenizers": {
-			"version": "1.0.24",
-			"requires": {
-				"clone": "^2.1.2"
-			}
-		},
-		"remark-external-links": {
-			"version": "8.0.0",
-			"requires": {
-				"extend": "^3.0.0",
-				"is-absolute-url": "^3.0.0",
-				"mdast-util-definitions": "^4.0.0",
-				"space-separated-tokens": "^1.0.0",
-				"unist-util-visit": "^2.0.0"
-			},
-			"dependencies": {
-				"unist-util-visit": {
-					"version": "2.0.3",
-					"requires": {
-						"@types/unist": "^2.0.0",
-						"unist-util-is": "^4.0.0",
-						"unist-util-visit-parents": "^3.0.0"
-					}
-				},
-				"unist-util-visit-parents": {
-					"version": "3.1.1",
-					"requires": {
-						"@types/unist": "^2.0.0",
-						"unist-util-is": "^4.0.0"
 					}
 				}
 			}
@@ -23079,12 +22127,6 @@
 				}
 			}
 		},
-		"remark-rehype": {
-			"version": "8.0.0",
-			"requires": {
-				"mdast-util-to-hast": "^10.0.0"
-			}
-		},
 		"remark-stringify": {
 			"version": "10.0.2",
 			"resolved": "https://registry.npmjs.org/remark-stringify/-/remark-stringify-10.0.2.tgz",
@@ -23158,9 +22200,6 @@
 					}
 				}
 			}
-		},
-		"repeat-string": {
-			"version": "1.6.1"
 		},
 		"require-from-string": {
 			"version": "2.0.2",
@@ -23631,9 +22670,6 @@
 				"source-map": "^0.6.0"
 			}
 		},
-		"space-separated-tokens": {
-			"version": "1.1.5"
-		},
 		"spdx-correct": {
 			"version": "3.1.1",
 			"resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.1.tgz",
@@ -23741,9 +22777,6 @@
 			"version": "2.4.1",
 			"resolved": "https://registry.npmjs.org/splitpanes/-/splitpanes-2.4.1.tgz",
 			"integrity": "sha512-kpEo1WuMXuc6QfdQdO2V/fl/trONlkUKp+pputsLTiW9RMtwEvjb4/aYGm2m3+KAzjmb+zLwr4A4SYZu74+pgQ=="
-		},
-		"state-toggle": {
-			"version": "1.0.3"
 		},
 		"statuses": {
 			"version": "2.0.1",
@@ -23983,12 +23016,6 @@
 			"integrity": "sha1-eVjHk+R+MuB9K1yv5cC/jhLneQI=",
 			"dev": true,
 			"peer": true
-		},
-		"style-to-object": {
-			"version": "0.3.0",
-			"requires": {
-				"inline-style-parser": "0.1.1"
-			}
 		},
 		"stylelint": {
 			"version": "14.10.0",
@@ -24360,21 +23387,12 @@
 		"tributejs": {
 			"version": "5.1.3"
 		},
-		"trim": {
-			"version": "0.0.1"
-		},
 		"trim-newlines": {
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-3.0.1.tgz",
 			"integrity": "sha512-c1PTsA3tYrIsLGkJkzHF+w9F2EyxfXGo4UyJc4pFL++FMjnq0HJS69T3M7d//gKrFKwy429bouPescbjecU+Zw==",
 			"dev": true,
 			"peer": true
-		},
-		"trim-trailing-lines": {
-			"version": "1.1.4"
-		},
-		"trough": {
-			"version": "1.0.5"
 		},
 		"tsconfig-paths": {
 			"version": "3.14.1",
@@ -24480,13 +23498,6 @@
 				"which-boxed-primitive": "^1.0.2"
 			}
 		},
-		"unherit": {
-			"version": "1.1.3",
-			"requires": {
-				"inherits": "^2.0.0",
-				"xtend": "^4.0.0"
-			}
-		},
 		"unicode-canonical-property-names-ecmascript": {
 			"version": "1.0.4",
 			"dev": true,
@@ -24510,80 +23521,6 @@
 			"version": "1.1.0",
 			"dev": true,
 			"peer": true
-		},
-		"unified": {
-			"version": "9.2.0",
-			"requires": {
-				"bail": "^1.0.0",
-				"extend": "^3.0.0",
-				"is-buffer": "^2.0.0",
-				"is-plain-obj": "^2.0.0",
-				"trough": "^1.0.0",
-				"vfile": "^4.0.0"
-			},
-			"dependencies": {
-				"is-buffer": {
-					"version": "2.0.5"
-				}
-			}
-		},
-		"unist-builder": {
-			"version": "2.0.3"
-		},
-		"unist-util-generated": {
-			"version": "1.1.6"
-		},
-		"unist-util-is": {
-			"version": "4.0.4"
-		},
-		"unist-util-position": {
-			"version": "3.1.0"
-		},
-		"unist-util-remove-position": {
-			"version": "2.0.1",
-			"requires": {
-				"unist-util-visit": "^2.0.0"
-			},
-			"dependencies": {
-				"unist-util-visit": {
-					"version": "2.0.3",
-					"requires": {
-						"@types/unist": "^2.0.0",
-						"unist-util-is": "^4.0.0",
-						"unist-util-visit-parents": "^3.0.0"
-					}
-				},
-				"unist-util-visit-parents": {
-					"version": "3.1.1",
-					"requires": {
-						"@types/unist": "^2.0.0",
-						"unist-util-is": "^4.0.0"
-					}
-				}
-			}
-		},
-		"unist-util-stringify-position": {
-			"version": "2.0.3",
-			"requires": {
-				"@types/unist": "^2.0.2"
-			}
-		},
-		"unist-util-visit": {
-			"version": "1.4.1",
-			"requires": {
-				"unist-util-visit-parents": "^2.0.0"
-			}
-		},
-		"unist-util-visit-parents": {
-			"version": "2.1.2",
-			"requires": {
-				"unist-util-is": "^3.0.0"
-			},
-			"dependencies": {
-				"unist-util-is": {
-					"version": "3.0.0"
-				}
-			}
 		},
 		"unpipe": {
 			"version": "1.0.0",
@@ -24704,30 +23641,6 @@
 			"integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
 			"dev": true,
 			"peer": true
-		},
-		"vfile": {
-			"version": "4.2.1",
-			"requires": {
-				"@types/unist": "^2.0.0",
-				"is-buffer": "^2.0.0",
-				"unist-util-stringify-position": "^2.0.0",
-				"vfile-message": "^2.0.0"
-			},
-			"dependencies": {
-				"is-buffer": {
-					"version": "2.0.5"
-				}
-			}
-		},
-		"vfile-location": {
-			"version": "3.2.0"
-		},
-		"vfile-message": {
-			"version": "2.0.4",
-			"requires": {
-				"@types/unist": "^2.0.0",
-				"unist-util-stringify-position": "^2.0.0"
-			}
 		},
 		"vm-browserify": {
 			"version": "1.1.2",
@@ -24951,9 +23864,6 @@
 			"requires": {
 				"minimalistic-assert": "^1.0.0"
 			}
-		},
-		"web-namespaces": {
-			"version": "1.1.4"
 		},
 		"webpack": {
 			"version": "5.74.0",
@@ -25295,7 +24205,9 @@
 			"peer": true
 		},
 		"xtend": {
-			"version": "4.0.2"
+			"version": "4.0.2",
+			"dev": true,
+			"peer": true
 		},
 		"yallist": {
 			"version": "2.1.2",
@@ -25322,9 +24234,6 @@
 			"version": "0.1.0",
 			"dev": true,
 			"peer": true
-		},
-		"zwitch": {
-			"version": "1.0.5"
 		}
 	}
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,6 @@
 				"@nextcloud/moment": "^1.2.1",
 				"@nextcloud/router": "^2.0.1",
 				"@nextcloud/vue": "^7.6.0",
-				"@nextcloud/vue-dashboard": "^2.0.1",
 				"debounce": "^1.2.1",
 				"remark": "^14.0.2",
 				"strip-markdown": "^5.0.0",
@@ -2281,23 +2280,6 @@
 				"node": ">=6.9.0"
 			}
 		},
-		"node_modules/@babel/polyfill": {
-			"version": "7.2.5",
-			"license": "MIT",
-			"dependencies": {
-				"core-js": "^2.5.7",
-				"regenerator-runtime": "^0.12.0"
-			}
-		},
-		"node_modules/@babel/polyfill/node_modules/core-js": {
-			"version": "2.6.12",
-			"hasInstallScript": true,
-			"license": "MIT"
-		},
-		"node_modules/@babel/polyfill/node_modules/regenerator-runtime": {
-			"version": "0.12.1",
-			"license": "MIT"
-		},
 		"node_modules/@babel/preset-env": {
 			"version": "7.14.5",
 			"dev": true,
@@ -2688,6 +2670,7 @@
 			"version": "0.3.2",
 			"resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.2.tgz",
 			"integrity": "sha512-mh65xKQAzI6iBcFzwv28KVWSmCkdRBWoOh+bYQGW3+6OZvbbN3TqMGo5hqYxQniRcH9F2VZIoJCm4pa3BPDK/A==",
+			"dev": true,
 			"peer": true,
 			"dependencies": {
 				"@jridgewell/set-array": "^1.0.1",
@@ -2702,6 +2685,7 @@
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.0.tgz",
 			"integrity": "sha512-F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w==",
+			"dev": true,
 			"peer": true,
 			"engines": {
 				"node": ">=6.0.0"
@@ -2711,6 +2695,7 @@
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.1.2.tgz",
 			"integrity": "sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw==",
+			"dev": true,
 			"peer": true,
 			"engines": {
 				"node": ">=6.0.0"
@@ -2720,6 +2705,7 @@
 			"version": "0.3.2",
 			"resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.2.tgz",
 			"integrity": "sha512-m7O9o2uR8k2ObDysZYzdfhb08VuEml5oWGiosa1VdaPZ/A6QyPkAJuwN0Q1lhULOf6B7MtQmHENS743hWtCrgw==",
+			"dev": true,
 			"peer": true,
 			"dependencies": {
 				"@jridgewell/gen-mapping": "^0.3.0",
@@ -2730,12 +2716,14 @@
 			"version": "1.4.14",
 			"resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz",
 			"integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==",
+			"dev": true,
 			"peer": true
 		},
 		"node_modules/@jridgewell/trace-mapping": {
 			"version": "0.3.14",
 			"resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.14.tgz",
 			"integrity": "sha512-bJWEfQ9lPTvm3SneWwRFVLzrh6nhjwqw7TUFFBEMzwvg7t7PCDenf2lDwqo4NQXzdpgBXyFgDWnQA+2vkruksQ==",
+			"dev": true,
 			"peer": true,
 			"dependencies": {
 				"@jridgewell/resolve-uri": "^3.0.3",
@@ -2856,22 +2844,6 @@
 				"@babel/plugin-transform-modules-commonjs": "^7.13.8",
 				"@babel/plugin-transform-shorthand-properties": "^7.12.13",
 				"@babel/preset-env": "^7.13.12"
-			}
-		},
-		"node_modules/@nextcloud/browser-storage": {
-			"version": "0.1.1",
-			"license": "GPL-3.0-or-later",
-			"dependencies": {
-				"core-js": "3.6.1"
-			}
-		},
-		"node_modules/@nextcloud/browser-storage/node_modules/core-js": {
-			"version": "3.6.1",
-			"hasInstallScript": true,
-			"license": "MIT",
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/core-js"
 			}
 		},
 		"node_modules/@nextcloud/browserslist-config": {
@@ -3137,166 +3109,6 @@
 				"npm": "^7.0.0 || ^8.0.0"
 			}
 		},
-		"node_modules/@nextcloud/vue-dashboard": {
-			"version": "2.0.1",
-			"license": "AGPL-3.0",
-			"dependencies": {
-				"@nextcloud/vue": "^3.1.1",
-				"core-js": "^3.6.4",
-				"vue": "^2.6.11"
-			},
-			"engines": {
-				"node": ">=10.0.0"
-			},
-			"peerDependencies": {
-				"@nextcloud/vue": "^3.1.1",
-				"vue": "^2.6.11"
-			}
-		},
-		"node_modules/@nextcloud/vue-dashboard/node_modules/@nextcloud/auth": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/@nextcloud/auth/-/auth-1.3.0.tgz",
-			"integrity": "sha512-GfwRM9W7hat4psNdAt74UHEV+drEXQ53klCVp6JpON66ZLPeK5eJ1LQuiQDkpUxZpqNeaumXjiB98h5cug/uQw==",
-			"dependencies": {
-				"@nextcloud/event-bus": "^1.1.3",
-				"@nextcloud/typings": "^0.2.2",
-				"core-js": "^3.6.4"
-			}
-		},
-		"node_modules/@nextcloud/vue-dashboard/node_modules/@nextcloud/axios": {
-			"version": "1.11.0",
-			"resolved": "https://registry.npmjs.org/@nextcloud/axios/-/axios-1.11.0.tgz",
-			"integrity": "sha512-NyaiSC2GX2CPaH/MUGGMTTTza/TW9ZqWNGWq6LJ+pLER8nqZ9BQkwJ5kXUYGo+i3cka68PO+9WhcDv4fSABpuQ==",
-			"dependencies": {
-				"@nextcloud/auth": "^1.3.0",
-				"axios": "^0.27.1",
-				"core-js": "^3.6.4"
-			},
-			"engines": {
-				"node": "^16.0.0",
-				"npm": "^7.0.0 || ^8.0.0"
-			}
-		},
-		"node_modules/@nextcloud/vue-dashboard/node_modules/@nextcloud/l10n": {
-			"version": "1.6.0",
-			"resolved": "https://registry.npmjs.org/@nextcloud/l10n/-/l10n-1.6.0.tgz",
-			"integrity": "sha512-aKGlgrwN9OiafN791sYus0shfwNeU3PlrH6Oi9ISma6iJSvN6a8aJM8WGKCJ9pqBaTR5PrDuckuM/WnybBWb6A==",
-			"dependencies": {
-				"core-js": "^3.6.4",
-				"node-gettext": "^3.0.0"
-			}
-		},
-		"node_modules/@nextcloud/vue-dashboard/node_modules/@nextcloud/router": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/@nextcloud/router/-/router-1.2.0.tgz",
-			"integrity": "sha512-kn9QsL9LuhkIMaSSgdiqRL3SZ6PatuAjXUiyq343BbSnI99Oc5eJH8kU6cT2AHije7wKy/tK8Xe3VQuVO32SZQ==",
-			"dependencies": {
-				"core-js": "^3.6.4"
-			}
-		},
-		"node_modules/@nextcloud/vue-dashboard/node_modules/@nextcloud/vue": {
-			"version": "3.10.2",
-			"resolved": "https://registry.npmjs.org/@nextcloud/vue/-/vue-3.10.2.tgz",
-			"integrity": "sha512-/8r2fE8V7nw9erjm06x3nCALC+6o9q2CzNSL0eDRfsKXCVySFoZ4bYX+zziQUStienisKDRXRhxh7RUAwkS2+w==",
-			"dependencies": {
-				"@nextcloud/auth": "^1.2.3",
-				"@nextcloud/axios": "^1.3.2",
-				"@nextcloud/browser-storage": "^0.1.1",
-				"@nextcloud/capabilities": "^1.0.2",
-				"@nextcloud/dialogs": "^3.0.0",
-				"@nextcloud/event-bus": "^1.1.4",
-				"@nextcloud/l10n": "^1.2.3",
-				"@nextcloud/router": "^1.0.2",
-				"core-js": "^3.6.5",
-				"debounce": "1.2.1",
-				"emoji-mart-vue-fast": "^7.0.7",
-				"escape-html": "^1.0.3",
-				"hammerjs": "^2.0.8",
-				"linkifyjs": "~2.1.9",
-				"md5": "^2.2.1",
-				"regenerator-runtime": "^0.13.5",
-				"string-length": "^4.0.1",
-				"striptags": "^3.1.1",
-				"style-loader": "^2.0.0",
-				"tributejs": "^5.1.3",
-				"v-click-outside": "^3.0.1",
-				"v-tooltip": "^2.0.3",
-				"vue": "^2.6.11",
-				"vue-color": "^2.7.1",
-				"vue-multiselect": "^2.1.6",
-				"vue-visible": "^1.0.2",
-				"vue2-datepicker": "^3.6.3"
-			},
-			"engines": {
-				"node": ">=10.0.0"
-			}
-		},
-		"node_modules/@nextcloud/vue-dashboard/node_modules/char-regex": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/char-regex/-/char-regex-1.0.2.tgz",
-			"integrity": "sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==",
-			"engines": {
-				"node": ">=10"
-			}
-		},
-		"node_modules/@nextcloud/vue-dashboard/node_modules/linkifyjs": {
-			"version": "2.1.9",
-			"resolved": "https://registry.npmjs.org/linkifyjs/-/linkifyjs-2.1.9.tgz",
-			"integrity": "sha512-74ivurkK6WHvHFozVaGtQWV38FzBwSTGNmJolEgFp7QgR2bl6ArUWlvT4GcHKbPe1z3nWYi+VUdDZk16zDOVug==",
-			"peerDependencies": {
-				"jquery": ">= 1.11.0",
-				"react": ">= 0.14.0",
-				"react-dom": ">= 0.14.0"
-			}
-		},
-		"node_modules/@nextcloud/vue-dashboard/node_modules/schema-utils": {
-			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.1.1.tgz",
-			"integrity": "sha512-Y5PQxS4ITlC+EahLuXaY86TXfR7Dc5lw294alXOq86JAHCihAIZfqv8nNCWvaEJvaC51uN9hbLGeV0cFBdH+Fw==",
-			"dependencies": {
-				"@types/json-schema": "^7.0.8",
-				"ajv": "^6.12.5",
-				"ajv-keywords": "^3.5.2"
-			},
-			"engines": {
-				"node": ">= 10.13.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/webpack"
-			}
-		},
-		"node_modules/@nextcloud/vue-dashboard/node_modules/string-length": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/string-length/-/string-length-4.0.2.tgz",
-			"integrity": "sha512-+l6rNN5fYHNhZZy41RXsYptCjA2Igmq4EG7kZAYFQI1E1VTXarr6ZPXBg6eq7Y6eK4FEhY6AJlyuFIb/v/S0VQ==",
-			"dependencies": {
-				"char-regex": "^1.0.2",
-				"strip-ansi": "^6.0.0"
-			},
-			"engines": {
-				"node": ">=10"
-			}
-		},
-		"node_modules/@nextcloud/vue-dashboard/node_modules/style-loader": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/style-loader/-/style-loader-2.0.0.tgz",
-			"integrity": "sha512-Z0gYUJmzZ6ZdRUqpg1r8GsaFKypE+3xAzuFeMuoHgjc9KZv3wMyCRjQIWEbhoFSq7+7yoHXySDJyyWQaPajeiQ==",
-			"dependencies": {
-				"loader-utils": "^2.0.0",
-				"schema-utils": "^3.0.0"
-			},
-			"engines": {
-				"node": ">= 10.13.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/webpack"
-			},
-			"peerDependencies": {
-				"webpack": "^4.0.0 || ^5.0.0"
-			}
-		},
 		"node_modules/@nextcloud/vue-select": {
 			"version": "3.22.2",
 			"resolved": "https://registry.npmjs.org/@nextcloud/vue-select/-/vue-select-3.22.2.tgz",
@@ -3523,6 +3335,7 @@
 			"version": "8.4.9",
 			"resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.4.9.tgz",
 			"integrity": "sha512-jFCSo4wJzlHQLCpceUhUnXdrPuCNOjGFMQ8Eg6JXxlz3QaCKOb7eGi2cephQdM4XTYsNej69P9JDJ1zqNIbncQ==",
+			"dev": true,
 			"peer": true,
 			"dependencies": {
 				"@types/estree": "*",
@@ -3533,6 +3346,7 @@
 			"version": "3.7.4",
 			"resolved": "https://registry.npmjs.org/@types/eslint-scope/-/eslint-scope-3.7.4.tgz",
 			"integrity": "sha512-9K4zoImiZc3HlIp6AVUDE4CWYx22a+lhSZMYNpbjW04+YF0KWj4pJXnEMjdnFTiQibFFmElcsasJXDbdI/EPhA==",
+			"dev": true,
 			"peer": true,
 			"dependencies": {
 				"@types/eslint": "*",
@@ -3543,6 +3357,7 @@
 			"version": "0.0.51",
 			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.51.tgz",
 			"integrity": "sha512-CuPgU6f3eT/XgKKPqKd/gLZV1Xmvf1a2R5POBOGQa6uv82xpls89HU5zKeVoyR8XzHd1RGNOlQlvUe3CFkjWNQ==",
+			"dev": true,
 			"peer": true
 		},
 		"node_modules/@types/express": {
@@ -3587,7 +3402,9 @@
 		"node_modules/@types/json-schema": {
 			"version": "7.0.9",
 			"resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.9.tgz",
-			"integrity": "sha512-qcUXuemtEu+E5wZSJHNxUXeCZhAfXKQ41D+duX+VYPde7xyEVZci+/oXKJL13tnRs9lR2pr4fod59GT6/X1/yQ=="
+			"integrity": "sha512-qcUXuemtEu+E5wZSJHNxUXeCZhAfXKQ41D+duX+VYPde7xyEVZci+/oXKJL13tnRs9lR2pr4fod59GT6/X1/yQ==",
+			"dev": true,
+			"peer": true
 		},
 		"node_modules/@types/json5": {
 			"version": "0.0.29",
@@ -3624,6 +3441,7 @@
 		},
 		"node_modules/@types/node": {
 			"version": "14.0.26",
+			"dev": true,
 			"license": "MIT",
 			"peer": true
 		},
@@ -4102,6 +3920,7 @@
 			"version": "1.11.1",
 			"resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.11.1.tgz",
 			"integrity": "sha512-ukBh14qFLjxTQNTXocdyksN5QdM28S1CxHt2rdskFyL+xFV7VremuBLVbmCePj+URalXBENx/9Lm7lnhihtCSw==",
+			"dev": true,
 			"peer": true,
 			"dependencies": {
 				"@webassemblyjs/helper-numbers": "1.11.1",
@@ -4112,24 +3931,28 @@
 			"version": "1.11.1",
 			"resolved": "https://registry.npmjs.org/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.11.1.tgz",
 			"integrity": "sha512-iGRfyc5Bq+NnNuX8b5hwBrRjzf0ocrJPI6GWFodBFzmFnyvrQ83SHKhmilCU/8Jv67i4GJZBMhEzltxzcNagtQ==",
+			"dev": true,
 			"peer": true
 		},
 		"node_modules/@webassemblyjs/helper-api-error": {
 			"version": "1.11.1",
 			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-api-error/-/helper-api-error-1.11.1.tgz",
 			"integrity": "sha512-RlhS8CBCXfRUR/cwo2ho9bkheSXG0+NwooXcc3PAILALf2QLdFyj7KGsKRbVc95hZnhnERon4kW/D3SZpp6Tcg==",
+			"dev": true,
 			"peer": true
 		},
 		"node_modules/@webassemblyjs/helper-buffer": {
 			"version": "1.11.1",
 			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-buffer/-/helper-buffer-1.11.1.tgz",
 			"integrity": "sha512-gwikF65aDNeeXa8JxXa2BAk+REjSyhrNC9ZwdT0f8jc4dQQeDQ7G4m0f2QCLPJiMTTO6wfDmRmj/pW0PsUvIcA==",
+			"dev": true,
 			"peer": true
 		},
 		"node_modules/@webassemblyjs/helper-numbers": {
 			"version": "1.11.1",
 			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-numbers/-/helper-numbers-1.11.1.tgz",
 			"integrity": "sha512-vDkbxiB8zfnPdNK9Rajcey5C0w+QJugEglN0of+kmO8l7lDb77AnlKYQF7aarZuCrv+l0UvqL+68gSDr3k9LPQ==",
+			"dev": true,
 			"peer": true,
 			"dependencies": {
 				"@webassemblyjs/floating-point-hex-parser": "1.11.1",
@@ -4141,12 +3964,14 @@
 			"version": "1.11.1",
 			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.11.1.tgz",
 			"integrity": "sha512-PvpoOGiJwXeTrSf/qfudJhwlvDQxFgelbMqtq52WWiXC6Xgg1IREdngmPN3bs4RoO83PnL/nFrxucXj1+BX62Q==",
+			"dev": true,
 			"peer": true
 		},
 		"node_modules/@webassemblyjs/helper-wasm-section": {
 			"version": "1.11.1",
 			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.11.1.tgz",
 			"integrity": "sha512-10P9No29rYX1j7F3EVPX3JvGPQPae+AomuSTPiF9eBQeChHI6iqjMIwR9JmOJXwpnn/oVGDk7I5IlskuMwU/pg==",
+			"dev": true,
 			"peer": true,
 			"dependencies": {
 				"@webassemblyjs/ast": "1.11.1",
@@ -4159,6 +3984,7 @@
 			"version": "1.11.1",
 			"resolved": "https://registry.npmjs.org/@webassemblyjs/ieee754/-/ieee754-1.11.1.tgz",
 			"integrity": "sha512-hJ87QIPtAMKbFq6CGTkZYJivEwZDbQUgYd3qKSadTNOhVY7p+gfP6Sr0lLRVTaG1JjFj+r3YchoqRYxNH3M0GQ==",
+			"dev": true,
 			"peer": true,
 			"dependencies": {
 				"@xtuc/ieee754": "^1.2.0"
@@ -4168,6 +3994,7 @@
 			"version": "1.11.1",
 			"resolved": "https://registry.npmjs.org/@webassemblyjs/leb128/-/leb128-1.11.1.tgz",
 			"integrity": "sha512-BJ2P0hNZ0u+Th1YZXJpzW6miwqQUGcIHT1G/sf72gLVD9DZ5AdYTqPNbHZh6K1M5VmKvFXwGSWZADz+qBWxeRw==",
+			"dev": true,
 			"peer": true,
 			"dependencies": {
 				"@xtuc/long": "4.2.2"
@@ -4177,12 +4004,14 @@
 			"version": "1.11.1",
 			"resolved": "https://registry.npmjs.org/@webassemblyjs/utf8/-/utf8-1.11.1.tgz",
 			"integrity": "sha512-9kqcxAEdMhiwQkHpkNiorZzqpGrodQQ2IGrHHxCy+Ozng0ofyMA0lTqiLkVs1uzTRejX+/O0EOT7KxqVPuXosQ==",
+			"dev": true,
 			"peer": true
 		},
 		"node_modules/@webassemblyjs/wasm-edit": {
 			"version": "1.11.1",
 			"resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-edit/-/wasm-edit-1.11.1.tgz",
 			"integrity": "sha512-g+RsupUC1aTHfR8CDgnsVRVZFJqdkFHpsHMfJuWQzWU3tvnLC07UqHICfP+4XyL2tnr1amvl1Sdp06TnYCmVkA==",
+			"dev": true,
 			"peer": true,
 			"dependencies": {
 				"@webassemblyjs/ast": "1.11.1",
@@ -4199,6 +4028,7 @@
 			"version": "1.11.1",
 			"resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-gen/-/wasm-gen-1.11.1.tgz",
 			"integrity": "sha512-F7QqKXwwNlMmsulj6+O7r4mmtAlCWfO/0HdgOxSklZfQcDu0TpLiD1mRt/zF25Bk59FIjEuGAIyn5ei4yMfLhA==",
+			"dev": true,
 			"peer": true,
 			"dependencies": {
 				"@webassemblyjs/ast": "1.11.1",
@@ -4212,6 +4042,7 @@
 			"version": "1.11.1",
 			"resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-opt/-/wasm-opt-1.11.1.tgz",
 			"integrity": "sha512-VqnkNqnZlU5EB64pp1l7hdm3hmQw7Vgqa0KF/KCNO9sIpI6Fk6brDEiX+iCOYrvMuBWDws0NkTOxYEb85XQHHw==",
+			"dev": true,
 			"peer": true,
 			"dependencies": {
 				"@webassemblyjs/ast": "1.11.1",
@@ -4224,6 +4055,7 @@
 			"version": "1.11.1",
 			"resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-parser/-/wasm-parser-1.11.1.tgz",
 			"integrity": "sha512-rrBujw+dJu32gYB7/Lup6UhdkPx9S9SnobZzRVL7VcBH9Bt9bCBLEuX/YXOOtBsOZ4NQrRykKhffRWHvigQvOA==",
+			"dev": true,
 			"peer": true,
 			"dependencies": {
 				"@webassemblyjs/ast": "1.11.1",
@@ -4238,6 +4070,7 @@
 			"version": "1.11.1",
 			"resolved": "https://registry.npmjs.org/@webassemblyjs/wast-printer/-/wast-printer-1.11.1.tgz",
 			"integrity": "sha512-IQboUWM4eKzWW+N/jij2sRatKMh99QEelo3Eb2q0qXkvPRISAj8Qxtmw5itwqK+TTkBuUIE45AxYPToqPtL5gg==",
+			"dev": true,
 			"peer": true,
 			"dependencies": {
 				"@webassemblyjs/ast": "1.11.1",
@@ -4287,12 +4120,14 @@
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/@xtuc/ieee754/-/ieee754-1.2.0.tgz",
 			"integrity": "sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA==",
+			"dev": true,
 			"peer": true
 		},
 		"node_modules/@xtuc/long": {
 			"version": "4.2.2",
 			"resolved": "https://registry.npmjs.org/@xtuc/long/-/long-4.2.2.tgz",
 			"integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==",
+			"dev": true,
 			"peer": true
 		},
 		"node_modules/abort-controller": {
@@ -4326,6 +4161,7 @@
 			"version": "8.8.0",
 			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.0.tgz",
 			"integrity": "sha512-QOxyigPVrpZ2GXT+PFyZTl6TtOFc5egxHIP9IlQ+RbupQuX4RkT/Bee4/kQuC02Xkzg84JcT7oLYtDIQxp+v7w==",
+			"dev": true,
 			"peer": true,
 			"bin": {
 				"acorn": "bin/acorn"
@@ -4348,6 +4184,8 @@
 			"version": "6.12.6",
 			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
 			"integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+			"dev": true,
+			"peer": true,
 			"dependencies": {
 				"fast-deep-equal": "^3.1.1",
 				"fast-json-stable-stringify": "^2.0.0",
@@ -4405,6 +4243,8 @@
 			"version": "3.5.2",
 			"resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
 			"integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
+			"dev": true,
+			"peer": true,
 			"peerDependencies": {
 				"ajv": "^6.9.1"
 			}
@@ -4426,6 +4266,8 @@
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
 			"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+			"dev": true,
+			"peer": true,
 			"engines": {
 				"node": ">=8"
 			}
@@ -4711,7 +4553,9 @@
 		},
 		"node_modules/big.js": {
 			"version": "5.2.2",
+			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": "*"
 			}
@@ -4926,6 +4770,7 @@
 			"version": "4.21.4",
 			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.4.tgz",
 			"integrity": "sha512-CBHJJdDmgjl3daYjN5Cp5kbTf1mUhZoS+beLklHIvkOWscs83YAhLlF3Wsh/lciQYAcbBJgTOD44VtG31ZM4Hw==",
+			"dev": true,
 			"funding": [
 				{
 					"type": "opencollective",
@@ -4979,6 +4824,7 @@
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
 			"integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+			"dev": true,
 			"peer": true
 		},
 		"node_modules/buffer-xor": {
@@ -5070,6 +4916,7 @@
 			"version": "1.0.30001426",
 			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001426.tgz",
 			"integrity": "sha512-n7cosrHLl8AWt0wwZw/PJZgUg3lV0gk9LMI7ikGJwhyhgsd2Nb65vKvmSexCqq/J7rbH3mFG6yZZiPR5dLPW5A==",
+			"dev": true,
 			"funding": [
 				{
 					"type": "opencollective",
@@ -5174,6 +5021,7 @@
 		},
 		"node_modules/chrome-trace-event": {
 			"version": "1.0.3",
+			"dev": true,
 			"license": "MIT",
 			"peer": true,
 			"engines": {
@@ -6026,6 +5874,7 @@
 			"version": "1.4.284",
 			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.284.tgz",
 			"integrity": "sha512-M8WEXFuKXMYMVr45fo8mq0wUrrJHheiKZf6BArTKk9ZBYCKJEOU5H8cdWgDT+qCVZf7Na4lVUaZsA+h6uA9+PA==",
+			"dev": true,
 			"peer": true
 		},
 		"node_modules/elliptic": {
@@ -6051,29 +5900,6 @@
 			"dev": true,
 			"peer": true
 		},
-		"node_modules/emoji-mart-vue-fast": {
-			"version": "7.0.7",
-			"license": "BSD-3-Clause",
-			"dependencies": {
-				"@babel/polyfill": "7.2.5",
-				"@babel/runtime": "7.3.4",
-				"vue-virtual-scroller": "^1.0.0-rc.2"
-			},
-			"peerDependencies": {
-				"vue": "^2.0.0"
-			}
-		},
-		"node_modules/emoji-mart-vue-fast/node_modules/@babel/runtime": {
-			"version": "7.3.4",
-			"license": "MIT",
-			"dependencies": {
-				"regenerator-runtime": "^0.12.0"
-			}
-		},
-		"node_modules/emoji-mart-vue-fast/node_modules/regenerator-runtime": {
-			"version": "0.12.1",
-			"license": "MIT"
-		},
 		"node_modules/emoji-regex": {
 			"version": "8.0.0",
 			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
@@ -6085,6 +5911,8 @@
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-3.0.0.tgz",
 			"integrity": "sha512-/kyM18EfinwXZbno9FyUGeFh87KC8HRQBQGildHZbEuRyWFOmv1U10o9BBp8XVZDVNNuQKyIGIu5ZYAAXJ0V2Q==",
+			"dev": true,
+			"peer": true,
 			"engines": {
 				"node": ">= 4"
 			}
@@ -6103,6 +5931,7 @@
 			"version": "5.10.0",
 			"resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.10.0.tgz",
 			"integrity": "sha512-T0yTFjdpldGY8PmuXXR0PyQ1ufZpEGiHVrp7zHKB7jdR4qlmZHhONVM5AQOAWXuF/w3dnHbEQVrNptJgt7F+cQ==",
+			"dev": true,
 			"peer": true,
 			"dependencies": {
 				"graceful-fs": "^4.2.4",
@@ -6190,6 +6019,7 @@
 			"version": "0.9.3",
 			"resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-0.9.3.tgz",
 			"integrity": "sha512-1HQ2M2sPtxwnvOvT1ZClHyQDiggdNjURWpY2we6aMKCQiUVxTmVs2UYPLIrD84sS+kMdUwfBSylbJPwNnBrnHQ==",
+			"dev": true,
 			"peer": true
 		},
 		"node_modules/es-shim-unscopables": {
@@ -6231,6 +6061,7 @@
 			"version": "3.1.1",
 			"resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
 			"integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
+			"dev": true,
 			"peer": true,
 			"engines": {
 				"node": ">=6"
@@ -6634,6 +6465,7 @@
 		},
 		"node_modules/eslint-scope": {
 			"version": "5.1.1",
+			"dev": true,
 			"license": "BSD-2-Clause",
 			"peer": true,
 			"dependencies": {
@@ -6918,6 +6750,7 @@
 			"version": "4.3.0",
 			"resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
 			"integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+			"dev": true,
 			"peer": true,
 			"dependencies": {
 				"estraverse": "^5.2.0"
@@ -6930,6 +6763,7 @@
 			"version": "5.3.0",
 			"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
 			"integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+			"dev": true,
 			"peer": true,
 			"engines": {
 				"node": ">=4.0"
@@ -6937,6 +6771,7 @@
 		},
 		"node_modules/estraverse": {
 			"version": "4.3.0",
+			"dev": true,
 			"license": "BSD-2-Clause",
 			"peer": true,
 			"engines": {
@@ -6981,6 +6816,7 @@
 		},
 		"node_modules/events": {
 			"version": "3.3.0",
+			"dev": true,
 			"license": "MIT",
 			"peer": true,
 			"engines": {
@@ -7100,7 +6936,9 @@
 		"node_modules/fast-deep-equal": {
 			"version": "3.1.3",
 			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-			"integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
+			"integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+			"dev": true,
+			"peer": true
 		},
 		"node_modules/fast-glob": {
 			"version": "3.2.11",
@@ -7121,7 +6959,9 @@
 		},
 		"node_modules/fast-json-stable-stringify": {
 			"version": "2.1.0",
-			"license": "MIT"
+			"dev": true,
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/fast-levenshtein": {
 			"version": "2.0.6",
@@ -7536,6 +7376,7 @@
 			"version": "0.4.1",
 			"resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
 			"integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==",
+			"dev": true,
 			"peer": true
 		},
 		"node_modules/global-modules": {
@@ -7620,6 +7461,7 @@
 			"version": "4.2.10",
 			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
 			"integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==",
+			"dev": true,
 			"peer": true
 		},
 		"node_modules/grapheme-splitter": {
@@ -8724,6 +8566,7 @@
 			"version": "27.3.1",
 			"resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-27.3.1.tgz",
 			"integrity": "sha512-ks3WCzsiZaOPJl/oMsDjaf0TRiSv7ctNgs0FqRr2nARsovz6AWWy4oLElwcquGSz692DzgZQrCLScPNs5YlC4g==",
+			"dev": true,
 			"peer": true,
 			"dependencies": {
 				"@types/node": "*",
@@ -8738,6 +8581,7 @@
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
 			"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+			"dev": true,
 			"peer": true,
 			"engines": {
 				"node": ">=8"
@@ -8747,6 +8591,7 @@
 			"version": "8.1.1",
 			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
 			"integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+			"dev": true,
 			"peer": true,
 			"dependencies": {
 				"has-flag": "^4.0.0"
@@ -8758,12 +8603,6 @@
 				"url": "https://github.com/chalk/supports-color?sponsor=1"
 			}
 		},
-		"node_modules/jquery": {
-			"version": "3.6.0",
-			"resolved": "https://registry.npmjs.org/jquery/-/jquery-3.6.0.tgz",
-			"integrity": "sha512-JVzAR/AjBvVt2BmYhxRCSYysDsPcssdmTFnzyLEts9qNwmjmu4JTAMYubEfwVOSwpQ1I1sKKFcxhZCI2buerfw==",
-			"peer": true
-		},
 		"node_modules/js-sdsl": {
 			"version": "4.1.5",
 			"resolved": "https://registry.npmjs.org/js-sdsl/-/js-sdsl-4.1.5.tgz",
@@ -8773,6 +8612,7 @@
 		},
 		"node_modules/js-tokens": {
 			"version": "4.0.0",
+			"dev": true,
 			"license": "MIT",
 			"peer": true
 		},
@@ -8815,11 +8655,14 @@
 			"version": "2.3.1",
 			"resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
 			"integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
+			"dev": true,
 			"peer": true
 		},
 		"node_modules/json-schema-traverse": {
 			"version": "0.4.1",
-			"license": "MIT"
+			"dev": true,
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/json-stable-stringify-without-jsonify": {
 			"version": "1.0.1",
@@ -8832,6 +8675,8 @@
 			"version": "2.2.3",
 			"resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
 			"integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+			"dev": true,
+			"peer": true,
 			"bin": {
 				"json5": "lib/cli.js"
 			},
@@ -8910,6 +8755,7 @@
 		},
 		"node_modules/loader-runner": {
 			"version": "4.2.0",
+			"dev": true,
 			"license": "MIT",
 			"peer": true,
 			"engines": {
@@ -8920,6 +8766,8 @@
 			"version": "2.0.4",
 			"resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.4.tgz",
 			"integrity": "sha512-xXqpXoINfFhgua9xiqD8fPFHgkoq1mmmpE92WlDbm9rNRd/EbRb+Gqf908T2DMfuHjjJlksiK2RbHVOdD/MqSw==",
+			"dev": true,
+			"peer": true,
 			"dependencies": {
 				"big.js": "^5.2.2",
 				"emojis-list": "^3.0.0",
@@ -8947,7 +8795,9 @@
 		},
 		"node_modules/lodash": {
 			"version": "4.17.21",
-			"license": "MIT"
+			"dev": true,
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/lodash.debounce": {
 			"version": "4.0.8",
@@ -8984,18 +8834,6 @@
 			"funding": {
 				"type": "github",
 				"url": "https://github.com/sponsors/wooorm"
-			}
-		},
-		"node_modules/loose-envify": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
-			"integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-			"peer": true,
-			"dependencies": {
-				"js-tokens": "^3.0.0 || ^4.0.0"
-			},
-			"bin": {
-				"loose-envify": "cli.js"
 			}
 		},
 		"node_modules/lru-cache": {
@@ -9559,6 +9397,7 @@
 		},
 		"node_modules/merge-stream": {
 			"version": "2.0.0",
+			"dev": true,
 			"license": "MIT",
 			"peer": true
 		},
@@ -10254,6 +10093,7 @@
 		},
 		"node_modules/neo-async": {
 			"version": "2.6.2",
+			"dev": true,
 			"license": "MIT",
 			"peer": true
 		},
@@ -10374,6 +10214,7 @@
 			"version": "2.0.6",
 			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.6.tgz",
 			"integrity": "sha512-PiVXnNuFm5+iYkLBNeq5211hvO38y63T0i2KKh2KnUs3RpzJ+JtODFjkD8yjLwnDkTYF1eKXheUwdssR+NRZdg==",
+			"dev": true,
 			"peer": true
 		},
 		"node_modules/normalize-path": {
@@ -10406,15 +10247,6 @@
 			"license": "BSD-2-Clause",
 			"dependencies": {
 				"boolbase": "~1.0.0"
-			}
-		},
-		"node_modules/object-assign": {
-			"version": "4.1.1",
-			"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-			"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
-			"peer": true,
-			"engines": {
-				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/object-inspect": {
@@ -10591,6 +10423,7 @@
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
 			"integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+			"dev": true,
 			"peer": true,
 			"dependencies": {
 				"yocto-queue": "^0.1.0"
@@ -10866,14 +10699,6 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/popper.js": {
-			"version": "1.16.1",
-			"license": "MIT",
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/popperjs"
-			}
-		},
 		"node_modules/postcss": {
 			"version": "8.4.18",
 			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.18.tgz",
@@ -11137,7 +10962,9 @@
 		},
 		"node_modules/punycode": {
 			"version": "2.1.1",
+			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": ">=6"
 			}
@@ -11212,6 +11039,7 @@
 		},
 		"node_modules/randombytes": {
 			"version": "2.1.0",
+			"dev": true,
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
@@ -11263,33 +11091,6 @@
 			"peer": true,
 			"engines": {
 				"node": ">= 0.8"
-			}
-		},
-		"node_modules/react": {
-			"version": "17.0.2",
-			"resolved": "https://registry.npmjs.org/react/-/react-17.0.2.tgz",
-			"integrity": "sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==",
-			"peer": true,
-			"dependencies": {
-				"loose-envify": "^1.1.0",
-				"object-assign": "^4.1.1"
-			},
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/react-dom": {
-			"version": "17.0.2",
-			"resolved": "https://registry.npmjs.org/react-dom/-/react-dom-17.0.2.tgz",
-			"integrity": "sha512-s4h96KtLDUQlsENhMn1ar8t2bEa+q/YAtj8pPPdIjPDGBDIVNsrD9aXNWqspUe6AzKCIG0C1HZZLqLV7qpOBGA==",
-			"peer": true,
-			"dependencies": {
-				"loose-envify": "^1.1.0",
-				"object-assign": "^4.1.1",
-				"scheduler": "^0.20.2"
-			},
-			"peerDependencies": {
-				"react": "17.0.2"
 			}
 		},
 		"node_modules/readable-stream": {
@@ -12090,6 +11891,7 @@
 		},
 		"node_modules/safe-buffer": {
 			"version": "5.1.2",
+			"dev": true,
 			"license": "MIT",
 			"peer": true
 		},
@@ -12157,16 +11959,6 @@
 				}
 			}
 		},
-		"node_modules/scheduler": {
-			"version": "0.20.2",
-			"resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.20.2.tgz",
-			"integrity": "sha512-2eWfGgAqqWFGqtdMmcL5zCMK1U8KlXv8SQFGglL3CEtd0aDVDWgeF/YoCmvln55m5zSk3J/20hTaSBeSObsQDQ==",
-			"peer": true,
-			"dependencies": {
-				"loose-envify": "^1.1.0",
-				"object-assign": "^4.1.1"
-			}
-		},
 		"node_modules/schema-utils": {
 			"version": "2.7.1",
 			"resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-2.7.1.tgz",
@@ -12185,10 +11977,6 @@
 				"type": "opencollective",
 				"url": "https://opencollective.com/webpack"
 			}
-		},
-		"node_modules/scrollparent": {
-			"version": "2.0.1",
-			"license": "ISC"
 		},
 		"node_modules/select-hose": {
 			"version": "2.0.0",
@@ -12274,6 +12062,7 @@
 		},
 		"node_modules/serialize-javascript": {
 			"version": "5.0.1",
+			"dev": true,
 			"license": "BSD-3-Clause",
 			"peer": true,
 			"dependencies": {
@@ -12547,6 +12336,7 @@
 			"version": "0.5.21",
 			"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
 			"integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
+			"dev": true,
 			"peer": true,
 			"dependencies": {
 				"buffer-from": "^1.0.0",
@@ -12824,6 +12614,8 @@
 			"version": "6.0.1",
 			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
 			"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+			"dev": true,
+			"peer": true,
 			"dependencies": {
 				"ansi-regex": "^5.0.1"
 			},
@@ -13396,6 +13188,7 @@
 			"version": "2.2.1",
 			"resolved": "https://registry.npmjs.org/tapable/-/tapable-2.2.1.tgz",
 			"integrity": "sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==",
+			"dev": true,
 			"peer": true,
 			"engines": {
 				"node": ">=6"
@@ -13405,6 +13198,7 @@
 			"version": "5.14.2",
 			"resolved": "https://registry.npmjs.org/terser/-/terser-5.14.2.tgz",
 			"integrity": "sha512-oL0rGeM/WFQCUd0y2QrWxYnq7tfSuKBiqTjRPWrRgB46WD/kiwHwF8T23z78H6Q6kGCuuHcPB+KULHRdxvVGQA==",
+			"dev": true,
 			"peer": true,
 			"dependencies": {
 				"@jridgewell/source-map": "^0.3.2",
@@ -13421,6 +13215,7 @@
 		},
 		"node_modules/terser-webpack-plugin": {
 			"version": "5.1.3",
+			"dev": true,
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
@@ -13444,6 +13239,7 @@
 		},
 		"node_modules/terser-webpack-plugin/node_modules/schema-utils": {
 			"version": "3.0.0",
+			"dev": true,
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
@@ -13461,6 +13257,7 @@
 		},
 		"node_modules/terser/node_modules/commander": {
 			"version": "2.20.3",
+			"dev": true,
 			"license": "MIT",
 			"peer": true
 		},
@@ -13899,6 +13696,7 @@
 			"version": "1.0.10",
 			"resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.10.tgz",
 			"integrity": "sha512-OztqDenkfFkbSG+tRxBeAnCVPckDBcvibKd35yDONx6OU8N7sqgwc7rCbkJ/WcYtVRZ4ba68d6byhC21GFh7sQ==",
+			"dev": true,
 			"funding": [
 				{
 					"type": "opencollective",
@@ -13923,7 +13721,9 @@
 		},
 		"node_modules/uri-js": {
 			"version": "4.2.2",
+			"dev": true,
 			"license": "BSD-2-Clause",
+			"peer": true,
 			"dependencies": {
 				"punycode": "^2.1.0"
 			}
@@ -14009,26 +13809,6 @@
 			"integrity": "sha512-QD0bDy38SHJXQBjgnllmkI/rbdiwmq9RC+/+pvrFjYJKTn8dtp7Penf9q1lLBta280fYG2q53mgLhQ+3l3z74w==",
 			"engines": {
 				"node": ">=6"
-			}
-		},
-		"node_modules/v-tooltip": {
-			"version": "2.1.3",
-			"license": "MIT",
-			"dependencies": {
-				"@babel/runtime": "^7.13.10",
-				"lodash": "^4.17.21",
-				"popper.js": "^1.16.1",
-				"vue-resize": "^1.0.1"
-			}
-		},
-		"node_modules/v-tooltip/node_modules/vue-resize": {
-			"version": "1.0.1",
-			"license": "MIT",
-			"dependencies": {
-				"@babel/runtime": "^7.13.10"
-			},
-			"peerDependencies": {
-				"vue": "^2.6.0"
 			}
 		},
 		"node_modules/v8-compile-cache": {
@@ -14298,17 +14078,6 @@
 				"npm": ">= 3.0.0"
 			}
 		},
-		"node_modules/vue-observe-visibility": {
-			"version": "0.4.6",
-			"license": "MIT"
-		},
-		"node_modules/vue-resize": {
-			"version": "0.4.5",
-			"license": "MIT",
-			"peerDependencies": {
-				"vue": "^2.3.0"
-			}
-		},
 		"node_modules/vue-style-loader": {
 			"version": "4.1.3",
 			"resolved": "https://registry.npmjs.org/vue-style-loader/-/vue-style-loader-4.1.3.tgz",
@@ -14365,22 +14134,6 @@
 			"dev": true,
 			"peer": true
 		},
-		"node_modules/vue-virtual-scroller": {
-			"version": "1.0.10",
-			"license": "MIT",
-			"dependencies": {
-				"scrollparent": "^2.0.1",
-				"vue-observe-visibility": "^0.4.4",
-				"vue-resize": "^0.4.5"
-			},
-			"peerDependencies": {
-				"vue": "^2.6.11"
-			}
-		},
-		"node_modules/vue-visible": {
-			"version": "1.0.2",
-			"license": "MIT"
-		},
 		"node_modules/vue2-datepicker": {
 			"version": "3.11.0",
 			"resolved": "https://registry.npmjs.org/vue2-datepicker/-/vue2-datepicker-3.11.0.tgz",
@@ -14403,6 +14156,7 @@
 			"version": "2.4.0",
 			"resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.4.0.tgz",
 			"integrity": "sha512-Lcvm7MGST/4fup+ifyKi2hjyIAwcdI4HRgtvTpIUxBRhB+RFtUh8XtDOxUfctVCnhVi+QQj49i91OyvzkJl6cg==",
+			"dev": true,
 			"peer": true,
 			"dependencies": {
 				"glob-to-regexp": "^0.4.1",
@@ -14434,6 +14188,7 @@
 			"version": "5.74.0",
 			"resolved": "https://registry.npmjs.org/webpack/-/webpack-5.74.0.tgz",
 			"integrity": "sha512-A2InDwnhhGN4LYctJj6M1JEaGL7Luj6LOmyBHjcI8529cm5p6VXiTIW2sn6ffvEAKmveLzvu4jrihwXtPojlAA==",
+			"dev": true,
 			"peer": true,
 			"dependencies": {
 				"@types/eslint-scope": "^3.7.3",
@@ -14737,6 +14492,7 @@
 			"version": "3.2.3",
 			"resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.2.3.tgz",
 			"integrity": "sha512-/DyMEOrDgLKKIG0fmvtz+4dUX/3Ghozwgm6iPp8KRhvn+eQf9+Q7GWxVNMk3+uCPWfdXYC4ExGBckIXdFEfH1w==",
+			"dev": true,
 			"peer": true,
 			"engines": {
 				"node": ">=10.13.0"
@@ -14746,6 +14502,7 @@
 			"version": "1.8.0",
 			"resolved": "https://registry.npmjs.org/acorn-import-assertions/-/acorn-import-assertions-1.8.0.tgz",
 			"integrity": "sha512-m7VZ3jwz4eK6A4Vtt8Ew1/mNbP24u0FhdyfA7fSvnJR6LMdfOYnmuIrrJAgrYfYJ10F/otaHTtrtrtmHdMNzEw==",
+			"dev": true,
 			"peer": true,
 			"peerDependencies": {
 				"acorn": "^8"
@@ -14755,6 +14512,7 @@
 			"version": "3.1.1",
 			"resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.1.1.tgz",
 			"integrity": "sha512-Y5PQxS4ITlC+EahLuXaY86TXfR7Dc5lw294alXOq86JAHCihAIZfqv8nNCWvaEJvaC51uN9hbLGeV0cFBdH+Fw==",
+			"dev": true,
 			"peer": true,
 			"dependencies": {
 				"@types/json-schema": "^7.0.8",
@@ -14953,6 +14711,7 @@
 		},
 		"node_modules/yocto-queue": {
 			"version": "0.1.0",
+			"dev": true,
 			"license": "MIT",
 			"peer": true,
 			"engines": {
@@ -16470,21 +16229,6 @@
 				}
 			}
 		},
-		"@babel/polyfill": {
-			"version": "7.2.5",
-			"requires": {
-				"core-js": "^2.5.7",
-				"regenerator-runtime": "^0.12.0"
-			},
-			"dependencies": {
-				"core-js": {
-					"version": "2.6.12"
-				},
-				"regenerator-runtime": {
-					"version": "0.12.1"
-				}
-			}
-		},
 		"@babel/preset-env": {
 			"version": "7.14.5",
 			"dev": true,
@@ -16794,6 +16538,7 @@
 			"version": "0.3.2",
 			"resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.2.tgz",
 			"integrity": "sha512-mh65xKQAzI6iBcFzwv28KVWSmCkdRBWoOh+bYQGW3+6OZvbbN3TqMGo5hqYxQniRcH9F2VZIoJCm4pa3BPDK/A==",
+			"dev": true,
 			"peer": true,
 			"requires": {
 				"@jridgewell/set-array": "^1.0.1",
@@ -16805,18 +16550,21 @@
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.0.tgz",
 			"integrity": "sha512-F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w==",
+			"dev": true,
 			"peer": true
 		},
 		"@jridgewell/set-array": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.1.2.tgz",
 			"integrity": "sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw==",
+			"dev": true,
 			"peer": true
 		},
 		"@jridgewell/source-map": {
 			"version": "0.3.2",
 			"resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.2.tgz",
 			"integrity": "sha512-m7O9o2uR8k2ObDysZYzdfhb08VuEml5oWGiosa1VdaPZ/A6QyPkAJuwN0Q1lhULOf6B7MtQmHENS743hWtCrgw==",
+			"dev": true,
 			"peer": true,
 			"requires": {
 				"@jridgewell/gen-mapping": "^0.3.0",
@@ -16827,12 +16575,14 @@
 			"version": "1.4.14",
 			"resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz",
 			"integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==",
+			"dev": true,
 			"peer": true
 		},
 		"@jridgewell/trace-mapping": {
 			"version": "0.3.14",
 			"resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.14.tgz",
 			"integrity": "sha512-bJWEfQ9lPTvm3SneWwRFVLzrh6nhjwqw7TUFFBEMzwvg7t7PCDenf2lDwqo4NQXzdpgBXyFgDWnQA+2vkruksQ==",
+			"dev": true,
 			"peer": true,
 			"requires": {
 				"@jridgewell/resolve-uri": "^3.0.3",
@@ -16927,17 +16677,6 @@
 			"integrity": "sha512-olz7sqPD7xMDP2KcYwODtitH37faR/C5jKX1oxXzdDf+s1FRy6OQTC5ZqZR2LHZA6jTUvmwM/xWBPoEB/HPFRw==",
 			"dev": true,
 			"requires": {}
-		},
-		"@nextcloud/browser-storage": {
-			"version": "0.1.1",
-			"requires": {
-				"core-js": "3.6.1"
-			},
-			"dependencies": {
-				"core-js": {
-					"version": "3.6.1"
-				}
-			}
 		},
 		"@nextcloud/browserslist-config": {
 			"version": "2.3.0",
@@ -17218,126 +16957,6 @@
 				}
 			}
 		},
-		"@nextcloud/vue-dashboard": {
-			"version": "2.0.1",
-			"requires": {
-				"@nextcloud/vue": "^3.1.1",
-				"core-js": "^3.6.4",
-				"vue": "^2.6.11"
-			},
-			"dependencies": {
-				"@nextcloud/auth": {
-					"version": "1.3.0",
-					"resolved": "https://registry.npmjs.org/@nextcloud/auth/-/auth-1.3.0.tgz",
-					"integrity": "sha512-GfwRM9W7hat4psNdAt74UHEV+drEXQ53klCVp6JpON66ZLPeK5eJ1LQuiQDkpUxZpqNeaumXjiB98h5cug/uQw==",
-					"requires": {
-						"@nextcloud/event-bus": "^1.1.3",
-						"@nextcloud/typings": "^0.2.2",
-						"core-js": "^3.6.4"
-					}
-				},
-				"@nextcloud/axios": {
-					"version": "1.11.0",
-					"resolved": "https://registry.npmjs.org/@nextcloud/axios/-/axios-1.11.0.tgz",
-					"integrity": "sha512-NyaiSC2GX2CPaH/MUGGMTTTza/TW9ZqWNGWq6LJ+pLER8nqZ9BQkwJ5kXUYGo+i3cka68PO+9WhcDv4fSABpuQ==",
-					"requires": {
-						"@nextcloud/auth": "^1.3.0",
-						"axios": "^0.27.1",
-						"core-js": "^3.6.4"
-					}
-				},
-				"@nextcloud/l10n": {
-					"version": "1.6.0",
-					"resolved": "https://registry.npmjs.org/@nextcloud/l10n/-/l10n-1.6.0.tgz",
-					"integrity": "sha512-aKGlgrwN9OiafN791sYus0shfwNeU3PlrH6Oi9ISma6iJSvN6a8aJM8WGKCJ9pqBaTR5PrDuckuM/WnybBWb6A==",
-					"requires": {
-						"core-js": "^3.6.4",
-						"node-gettext": "^3.0.0"
-					}
-				},
-				"@nextcloud/router": {
-					"version": "1.2.0",
-					"resolved": "https://registry.npmjs.org/@nextcloud/router/-/router-1.2.0.tgz",
-					"integrity": "sha512-kn9QsL9LuhkIMaSSgdiqRL3SZ6PatuAjXUiyq343BbSnI99Oc5eJH8kU6cT2AHije7wKy/tK8Xe3VQuVO32SZQ==",
-					"requires": {
-						"core-js": "^3.6.4"
-					}
-				},
-				"@nextcloud/vue": {
-					"version": "3.10.2",
-					"resolved": "https://registry.npmjs.org/@nextcloud/vue/-/vue-3.10.2.tgz",
-					"integrity": "sha512-/8r2fE8V7nw9erjm06x3nCALC+6o9q2CzNSL0eDRfsKXCVySFoZ4bYX+zziQUStienisKDRXRhxh7RUAwkS2+w==",
-					"requires": {
-						"@nextcloud/auth": "^1.2.3",
-						"@nextcloud/axios": "^1.3.2",
-						"@nextcloud/browser-storage": "^0.1.1",
-						"@nextcloud/capabilities": "^1.0.2",
-						"@nextcloud/dialogs": "^3.0.0",
-						"@nextcloud/event-bus": "^1.1.4",
-						"@nextcloud/l10n": "^1.2.3",
-						"@nextcloud/router": "^1.0.2",
-						"core-js": "^3.6.5",
-						"debounce": "1.2.1",
-						"emoji-mart-vue-fast": "^7.0.7",
-						"escape-html": "^1.0.3",
-						"hammerjs": "^2.0.8",
-						"linkifyjs": "~2.1.9",
-						"md5": "^2.2.1",
-						"regenerator-runtime": "^0.13.5",
-						"string-length": "^4.0.1",
-						"striptags": "^3.1.1",
-						"style-loader": "^2.0.0",
-						"tributejs": "^5.1.3",
-						"v-click-outside": "^3.0.1",
-						"v-tooltip": "^2.0.3",
-						"vue": "^2.6.11",
-						"vue-color": "^2.7.1",
-						"vue-multiselect": "^2.1.6",
-						"vue-visible": "^1.0.2",
-						"vue2-datepicker": "^3.6.3"
-					}
-				},
-				"char-regex": {
-					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/char-regex/-/char-regex-1.0.2.tgz",
-					"integrity": "sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw=="
-				},
-				"linkifyjs": {
-					"version": "2.1.9",
-					"resolved": "https://registry.npmjs.org/linkifyjs/-/linkifyjs-2.1.9.tgz",
-					"integrity": "sha512-74ivurkK6WHvHFozVaGtQWV38FzBwSTGNmJolEgFp7QgR2bl6ArUWlvT4GcHKbPe1z3nWYi+VUdDZk16zDOVug==",
-					"requires": {}
-				},
-				"schema-utils": {
-					"version": "3.1.1",
-					"resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.1.1.tgz",
-					"integrity": "sha512-Y5PQxS4ITlC+EahLuXaY86TXfR7Dc5lw294alXOq86JAHCihAIZfqv8nNCWvaEJvaC51uN9hbLGeV0cFBdH+Fw==",
-					"requires": {
-						"@types/json-schema": "^7.0.8",
-						"ajv": "^6.12.5",
-						"ajv-keywords": "^3.5.2"
-					}
-				},
-				"string-length": {
-					"version": "4.0.2",
-					"resolved": "https://registry.npmjs.org/string-length/-/string-length-4.0.2.tgz",
-					"integrity": "sha512-+l6rNN5fYHNhZZy41RXsYptCjA2Igmq4EG7kZAYFQI1E1VTXarr6ZPXBg6eq7Y6eK4FEhY6AJlyuFIb/v/S0VQ==",
-					"requires": {
-						"char-regex": "^1.0.2",
-						"strip-ansi": "^6.0.0"
-					}
-				},
-				"style-loader": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/style-loader/-/style-loader-2.0.0.tgz",
-					"integrity": "sha512-Z0gYUJmzZ6ZdRUqpg1r8GsaFKypE+3xAzuFeMuoHgjc9KZv3wMyCRjQIWEbhoFSq7+7yoHXySDJyyWQaPajeiQ==",
-					"requires": {
-						"loader-utils": "^2.0.0",
-						"schema-utils": "^3.0.0"
-					}
-				}
-			}
-		},
 		"@nextcloud/vue-select": {
 			"version": "3.22.2",
 			"resolved": "https://registry.npmjs.org/@nextcloud/vue-select/-/vue-select-3.22.2.tgz",
@@ -17442,6 +17061,7 @@
 			"version": "8.4.9",
 			"resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.4.9.tgz",
 			"integrity": "sha512-jFCSo4wJzlHQLCpceUhUnXdrPuCNOjGFMQ8Eg6JXxlz3QaCKOb7eGi2cephQdM4XTYsNej69P9JDJ1zqNIbncQ==",
+			"dev": true,
 			"peer": true,
 			"requires": {
 				"@types/estree": "*",
@@ -17452,6 +17072,7 @@
 			"version": "3.7.4",
 			"resolved": "https://registry.npmjs.org/@types/eslint-scope/-/eslint-scope-3.7.4.tgz",
 			"integrity": "sha512-9K4zoImiZc3HlIp6AVUDE4CWYx22a+lhSZMYNpbjW04+YF0KWj4pJXnEMjdnFTiQibFFmElcsasJXDbdI/EPhA==",
+			"dev": true,
 			"peer": true,
 			"requires": {
 				"@types/eslint": "*",
@@ -17462,6 +17083,7 @@
 			"version": "0.0.51",
 			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.51.tgz",
 			"integrity": "sha512-CuPgU6f3eT/XgKKPqKd/gLZV1Xmvf1a2R5POBOGQa6uv82xpls89HU5zKeVoyR8XzHd1RGNOlQlvUe3CFkjWNQ==",
+			"dev": true,
 			"peer": true
 		},
 		"@types/express": {
@@ -17505,7 +17127,9 @@
 		"@types/json-schema": {
 			"version": "7.0.9",
 			"resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.9.tgz",
-			"integrity": "sha512-qcUXuemtEu+E5wZSJHNxUXeCZhAfXKQ41D+duX+VYPde7xyEVZci+/oXKJL13tnRs9lR2pr4fod59GT6/X1/yQ=="
+			"integrity": "sha512-qcUXuemtEu+E5wZSJHNxUXeCZhAfXKQ41D+duX+VYPde7xyEVZci+/oXKJL13tnRs9lR2pr4fod59GT6/X1/yQ==",
+			"dev": true,
+			"peer": true
 		},
 		"@types/json5": {
 			"version": "0.0.29",
@@ -17541,6 +17165,7 @@
 		},
 		"@types/node": {
 			"version": "14.0.26",
+			"dev": true,
 			"peer": true
 		},
 		"@types/normalize-package-data": {
@@ -17884,6 +17509,7 @@
 			"version": "1.11.1",
 			"resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.11.1.tgz",
 			"integrity": "sha512-ukBh14qFLjxTQNTXocdyksN5QdM28S1CxHt2rdskFyL+xFV7VremuBLVbmCePj+URalXBENx/9Lm7lnhihtCSw==",
+			"dev": true,
 			"peer": true,
 			"requires": {
 				"@webassemblyjs/helper-numbers": "1.11.1",
@@ -17894,24 +17520,28 @@
 			"version": "1.11.1",
 			"resolved": "https://registry.npmjs.org/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.11.1.tgz",
 			"integrity": "sha512-iGRfyc5Bq+NnNuX8b5hwBrRjzf0ocrJPI6GWFodBFzmFnyvrQ83SHKhmilCU/8Jv67i4GJZBMhEzltxzcNagtQ==",
+			"dev": true,
 			"peer": true
 		},
 		"@webassemblyjs/helper-api-error": {
 			"version": "1.11.1",
 			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-api-error/-/helper-api-error-1.11.1.tgz",
 			"integrity": "sha512-RlhS8CBCXfRUR/cwo2ho9bkheSXG0+NwooXcc3PAILALf2QLdFyj7KGsKRbVc95hZnhnERon4kW/D3SZpp6Tcg==",
+			"dev": true,
 			"peer": true
 		},
 		"@webassemblyjs/helper-buffer": {
 			"version": "1.11.1",
 			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-buffer/-/helper-buffer-1.11.1.tgz",
 			"integrity": "sha512-gwikF65aDNeeXa8JxXa2BAk+REjSyhrNC9ZwdT0f8jc4dQQeDQ7G4m0f2QCLPJiMTTO6wfDmRmj/pW0PsUvIcA==",
+			"dev": true,
 			"peer": true
 		},
 		"@webassemblyjs/helper-numbers": {
 			"version": "1.11.1",
 			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-numbers/-/helper-numbers-1.11.1.tgz",
 			"integrity": "sha512-vDkbxiB8zfnPdNK9Rajcey5C0w+QJugEglN0of+kmO8l7lDb77AnlKYQF7aarZuCrv+l0UvqL+68gSDr3k9LPQ==",
+			"dev": true,
 			"peer": true,
 			"requires": {
 				"@webassemblyjs/floating-point-hex-parser": "1.11.1",
@@ -17923,12 +17553,14 @@
 			"version": "1.11.1",
 			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.11.1.tgz",
 			"integrity": "sha512-PvpoOGiJwXeTrSf/qfudJhwlvDQxFgelbMqtq52WWiXC6Xgg1IREdngmPN3bs4RoO83PnL/nFrxucXj1+BX62Q==",
+			"dev": true,
 			"peer": true
 		},
 		"@webassemblyjs/helper-wasm-section": {
 			"version": "1.11.1",
 			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.11.1.tgz",
 			"integrity": "sha512-10P9No29rYX1j7F3EVPX3JvGPQPae+AomuSTPiF9eBQeChHI6iqjMIwR9JmOJXwpnn/oVGDk7I5IlskuMwU/pg==",
+			"dev": true,
 			"peer": true,
 			"requires": {
 				"@webassemblyjs/ast": "1.11.1",
@@ -17941,6 +17573,7 @@
 			"version": "1.11.1",
 			"resolved": "https://registry.npmjs.org/@webassemblyjs/ieee754/-/ieee754-1.11.1.tgz",
 			"integrity": "sha512-hJ87QIPtAMKbFq6CGTkZYJivEwZDbQUgYd3qKSadTNOhVY7p+gfP6Sr0lLRVTaG1JjFj+r3YchoqRYxNH3M0GQ==",
+			"dev": true,
 			"peer": true,
 			"requires": {
 				"@xtuc/ieee754": "^1.2.0"
@@ -17950,6 +17583,7 @@
 			"version": "1.11.1",
 			"resolved": "https://registry.npmjs.org/@webassemblyjs/leb128/-/leb128-1.11.1.tgz",
 			"integrity": "sha512-BJ2P0hNZ0u+Th1YZXJpzW6miwqQUGcIHT1G/sf72gLVD9DZ5AdYTqPNbHZh6K1M5VmKvFXwGSWZADz+qBWxeRw==",
+			"dev": true,
 			"peer": true,
 			"requires": {
 				"@xtuc/long": "4.2.2"
@@ -17959,12 +17593,14 @@
 			"version": "1.11.1",
 			"resolved": "https://registry.npmjs.org/@webassemblyjs/utf8/-/utf8-1.11.1.tgz",
 			"integrity": "sha512-9kqcxAEdMhiwQkHpkNiorZzqpGrodQQ2IGrHHxCy+Ozng0ofyMA0lTqiLkVs1uzTRejX+/O0EOT7KxqVPuXosQ==",
+			"dev": true,
 			"peer": true
 		},
 		"@webassemblyjs/wasm-edit": {
 			"version": "1.11.1",
 			"resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-edit/-/wasm-edit-1.11.1.tgz",
 			"integrity": "sha512-g+RsupUC1aTHfR8CDgnsVRVZFJqdkFHpsHMfJuWQzWU3tvnLC07UqHICfP+4XyL2tnr1amvl1Sdp06TnYCmVkA==",
+			"dev": true,
 			"peer": true,
 			"requires": {
 				"@webassemblyjs/ast": "1.11.1",
@@ -17981,6 +17617,7 @@
 			"version": "1.11.1",
 			"resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-gen/-/wasm-gen-1.11.1.tgz",
 			"integrity": "sha512-F7QqKXwwNlMmsulj6+O7r4mmtAlCWfO/0HdgOxSklZfQcDu0TpLiD1mRt/zF25Bk59FIjEuGAIyn5ei4yMfLhA==",
+			"dev": true,
 			"peer": true,
 			"requires": {
 				"@webassemblyjs/ast": "1.11.1",
@@ -17994,6 +17631,7 @@
 			"version": "1.11.1",
 			"resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-opt/-/wasm-opt-1.11.1.tgz",
 			"integrity": "sha512-VqnkNqnZlU5EB64pp1l7hdm3hmQw7Vgqa0KF/KCNO9sIpI6Fk6brDEiX+iCOYrvMuBWDws0NkTOxYEb85XQHHw==",
+			"dev": true,
 			"peer": true,
 			"requires": {
 				"@webassemblyjs/ast": "1.11.1",
@@ -18006,6 +17644,7 @@
 			"version": "1.11.1",
 			"resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-parser/-/wasm-parser-1.11.1.tgz",
 			"integrity": "sha512-rrBujw+dJu32gYB7/Lup6UhdkPx9S9SnobZzRVL7VcBH9Bt9bCBLEuX/YXOOtBsOZ4NQrRykKhffRWHvigQvOA==",
+			"dev": true,
 			"peer": true,
 			"requires": {
 				"@webassemblyjs/ast": "1.11.1",
@@ -18020,6 +17659,7 @@
 			"version": "1.11.1",
 			"resolved": "https://registry.npmjs.org/@webassemblyjs/wast-printer/-/wast-printer-1.11.1.tgz",
 			"integrity": "sha512-IQboUWM4eKzWW+N/jij2sRatKMh99QEelo3Eb2q0qXkvPRISAj8Qxtmw5itwqK+TTkBuUIE45AxYPToqPtL5gg==",
+			"dev": true,
 			"peer": true,
 			"requires": {
 				"@webassemblyjs/ast": "1.11.1",
@@ -18056,12 +17696,14 @@
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/@xtuc/ieee754/-/ieee754-1.2.0.tgz",
 			"integrity": "sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA==",
+			"dev": true,
 			"peer": true
 		},
 		"@xtuc/long": {
 			"version": "4.2.2",
 			"resolved": "https://registry.npmjs.org/@xtuc/long/-/long-4.2.2.tgz",
 			"integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==",
+			"dev": true,
 			"peer": true
 		},
 		"abort-controller": {
@@ -18089,6 +17731,7 @@
 			"version": "8.8.0",
 			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.0.tgz",
 			"integrity": "sha512-QOxyigPVrpZ2GXT+PFyZTl6TtOFc5egxHIP9IlQ+RbupQuX4RkT/Bee4/kQuC02Xkzg84JcT7oLYtDIQxp+v7w==",
+			"dev": true,
 			"peer": true
 		},
 		"acorn-jsx": {
@@ -18103,6 +17746,8 @@
 			"version": "6.12.6",
 			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
 			"integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+			"dev": true,
+			"peer": true,
 			"requires": {
 				"fast-deep-equal": "^3.1.1",
 				"fast-json-stable-stringify": "^2.0.0",
@@ -18146,6 +17791,8 @@
 			"version": "3.5.2",
 			"resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
 			"integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
+			"dev": true,
+			"peer": true,
 			"requires": {}
 		},
 		"ansi-html-community": {
@@ -18158,7 +17805,9 @@
 		"ansi-regex": {
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-			"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="
+			"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+			"dev": true,
+			"peer": true
 		},
 		"ansi-styles": {
 			"version": "3.2.1",
@@ -18370,7 +18019,9 @@
 			"peer": true
 		},
 		"big.js": {
-			"version": "5.2.2"
+			"version": "5.2.2",
+			"dev": true,
+			"peer": true
 		},
 		"binary-extensions": {
 			"version": "2.2.0",
@@ -18557,6 +18208,7 @@
 			"version": "4.21.4",
 			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.4.tgz",
 			"integrity": "sha512-CBHJJdDmgjl3daYjN5Cp5kbTf1mUhZoS+beLklHIvkOWscs83YAhLlF3Wsh/lciQYAcbBJgTOD44VtG31ZM4Hw==",
+			"dev": true,
 			"peer": true,
 			"requires": {
 				"caniuse-lite": "^1.0.30001400",
@@ -18580,6 +18232,7 @@
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
 			"integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+			"dev": true,
 			"peer": true
 		},
 		"buffer-xor": {
@@ -18654,6 +18307,7 @@
 			"version": "1.0.30001426",
 			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001426.tgz",
 			"integrity": "sha512-n7cosrHLl8AWt0wwZw/PJZgUg3lV0gk9LMI7ikGJwhyhgsd2Nb65vKvmSexCqq/J7rbH3mFG6yZZiPR5dLPW5A==",
+			"dev": true,
 			"peer": true
 		},
 		"ccount": {
@@ -18707,6 +18361,7 @@
 		},
 		"chrome-trace-event": {
 			"version": "1.0.3",
+			"dev": true,
 			"peer": true
 		},
 		"cipher-base": {
@@ -19371,6 +19026,7 @@
 			"version": "1.4.284",
 			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.284.tgz",
 			"integrity": "sha512-M8WEXFuKXMYMVr45fo8mq0wUrrJHheiKZf6BArTKk9ZBYCKJEOU5H8cdWgDT+qCVZf7Na4lVUaZsA+h6uA9+PA==",
+			"dev": true,
 			"peer": true
 		},
 		"elliptic": {
@@ -19398,25 +19054,6 @@
 				}
 			}
 		},
-		"emoji-mart-vue-fast": {
-			"version": "7.0.7",
-			"requires": {
-				"@babel/polyfill": "7.2.5",
-				"@babel/runtime": "7.3.4",
-				"vue-virtual-scroller": "^1.0.0-rc.2"
-			},
-			"dependencies": {
-				"@babel/runtime": {
-					"version": "7.3.4",
-					"requires": {
-						"regenerator-runtime": "^0.12.0"
-					}
-				},
-				"regenerator-runtime": {
-					"version": "0.12.1"
-				}
-			}
-		},
 		"emoji-regex": {
 			"version": "8.0.0",
 			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
@@ -19427,7 +19064,9 @@
 		"emojis-list": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-3.0.0.tgz",
-			"integrity": "sha512-/kyM18EfinwXZbno9FyUGeFh87KC8HRQBQGildHZbEuRyWFOmv1U10o9BBp8XVZDVNNuQKyIGIu5ZYAAXJ0V2Q=="
+			"integrity": "sha512-/kyM18EfinwXZbno9FyUGeFh87KC8HRQBQGildHZbEuRyWFOmv1U10o9BBp8XVZDVNNuQKyIGIu5ZYAAXJ0V2Q==",
+			"dev": true,
+			"peer": true
 		},
 		"encodeurl": {
 			"version": "1.0.2",
@@ -19440,6 +19079,7 @@
 			"version": "5.10.0",
 			"resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.10.0.tgz",
 			"integrity": "sha512-T0yTFjdpldGY8PmuXXR0PyQ1ufZpEGiHVrp7zHKB7jdR4qlmZHhONVM5AQOAWXuF/w3dnHbEQVrNptJgt7F+cQ==",
+			"dev": true,
 			"peer": true,
 			"requires": {
 				"graceful-fs": "^4.2.4",
@@ -19506,6 +19146,7 @@
 			"version": "0.9.3",
 			"resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-0.9.3.tgz",
 			"integrity": "sha512-1HQ2M2sPtxwnvOvT1ZClHyQDiggdNjURWpY2we6aMKCQiUVxTmVs2UYPLIrD84sS+kMdUwfBSylbJPwNnBrnHQ==",
+			"dev": true,
 			"peer": true
 		},
 		"es-shim-unscopables": {
@@ -19541,6 +19182,7 @@
 			"version": "3.1.1",
 			"resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
 			"integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
+			"dev": true,
 			"peer": true
 		},
 		"escape-html": {
@@ -19972,6 +19614,7 @@
 		},
 		"eslint-scope": {
 			"version": "5.1.1",
+			"dev": true,
 			"peer": true,
 			"requires": {
 				"esrecurse": "^4.3.0",
@@ -20039,6 +19682,7 @@
 			"version": "4.3.0",
 			"resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
 			"integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+			"dev": true,
 			"peer": true,
 			"requires": {
 				"estraverse": "^5.2.0"
@@ -20048,12 +19692,14 @@
 					"version": "5.3.0",
 					"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
 					"integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+					"dev": true,
 					"peer": true
 				}
 			}
 		},
 		"estraverse": {
 			"version": "4.3.0",
+			"dev": true,
 			"peer": true
 		},
 		"esutils": {
@@ -20084,6 +19730,7 @@
 		},
 		"events": {
 			"version": "3.3.0",
+			"dev": true,
 			"peer": true
 		},
 		"evp_bytestokey": {
@@ -20177,7 +19824,9 @@
 		"fast-deep-equal": {
 			"version": "3.1.3",
 			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-			"integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
+			"integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+			"dev": true,
+			"peer": true
 		},
 		"fast-glob": {
 			"version": "3.2.11",
@@ -20194,7 +19843,9 @@
 			}
 		},
 		"fast-json-stable-stringify": {
-			"version": "2.1.0"
+			"version": "2.1.0",
+			"dev": true,
+			"peer": true
 		},
 		"fast-levenshtein": {
 			"version": "2.0.6",
@@ -20495,6 +20146,7 @@
 			"version": "0.4.1",
 			"resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
 			"integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==",
+			"dev": true,
 			"peer": true
 		},
 		"global-modules": {
@@ -20562,6 +20214,7 @@
 			"version": "4.2.10",
 			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
 			"integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==",
+			"dev": true,
 			"peer": true
 		},
 		"grapheme-splitter": {
@@ -21323,6 +20976,7 @@
 			"version": "27.3.1",
 			"resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-27.3.1.tgz",
 			"integrity": "sha512-ks3WCzsiZaOPJl/oMsDjaf0TRiSv7ctNgs0FqRr2nARsovz6AWWy4oLElwcquGSz692DzgZQrCLScPNs5YlC4g==",
+			"dev": true,
 			"peer": true,
 			"requires": {
 				"@types/node": "*",
@@ -21334,24 +20988,20 @@
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
 					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+					"dev": true,
 					"peer": true
 				},
 				"supports-color": {
 					"version": "8.1.1",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
 					"integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+					"dev": true,
 					"peer": true,
 					"requires": {
 						"has-flag": "^4.0.0"
 					}
 				}
 			}
-		},
-		"jquery": {
-			"version": "3.6.0",
-			"resolved": "https://registry.npmjs.org/jquery/-/jquery-3.6.0.tgz",
-			"integrity": "sha512-JVzAR/AjBvVt2BmYhxRCSYysDsPcssdmTFnzyLEts9qNwmjmu4JTAMYubEfwVOSwpQ1I1sKKFcxhZCI2buerfw==",
-			"peer": true
 		},
 		"js-sdsl": {
 			"version": "4.1.5",
@@ -21362,6 +21012,7 @@
 		},
 		"js-tokens": {
 			"version": "4.0.0",
+			"dev": true,
 			"peer": true
 		},
 		"js-yaml": {
@@ -21390,10 +21041,13 @@
 			"version": "2.3.1",
 			"resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
 			"integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
+			"dev": true,
 			"peer": true
 		},
 		"json-schema-traverse": {
-			"version": "0.4.1"
+			"version": "0.4.1",
+			"dev": true,
+			"peer": true
 		},
 		"json-stable-stringify-without-jsonify": {
 			"version": "1.0.1",
@@ -21405,7 +21059,9 @@
 		"json5": {
 			"version": "2.2.3",
 			"resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
-			"integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg=="
+			"integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+			"dev": true,
+			"peer": true
 		},
 		"kind-of": {
 			"version": "6.0.3",
@@ -21463,12 +21119,15 @@
 		},
 		"loader-runner": {
 			"version": "4.2.0",
+			"dev": true,
 			"peer": true
 		},
 		"loader-utils": {
 			"version": "2.0.4",
 			"resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.4.tgz",
 			"integrity": "sha512-xXqpXoINfFhgua9xiqD8fPFHgkoq1mmmpE92WlDbm9rNRd/EbRb+Gqf908T2DMfuHjjJlksiK2RbHVOdD/MqSw==",
+			"dev": true,
+			"peer": true,
 			"requires": {
 				"big.js": "^5.2.2",
 				"emojis-list": "^3.0.0",
@@ -21486,7 +21145,9 @@
 			}
 		},
 		"lodash": {
-			"version": "4.17.21"
+			"version": "4.17.21",
+			"dev": true,
+			"peer": true
 		},
 		"lodash.debounce": {
 			"version": "4.0.8",
@@ -21517,15 +21178,6 @@
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-3.0.1.tgz",
 			"integrity": "sha512-cHlYSUpL2s7Fb3394mYxwTYj8niTaNHUCLr0qdiCXQfSjfuA7CKofpX2uSwEfFDQ0EB7JcnMnm+GjbqqoinYYg=="
-		},
-		"loose-envify": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
-			"integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-			"peer": true,
-			"requires": {
-				"js-tokens": "^3.0.0 || ^4.0.0"
-			}
 		},
 		"lru-cache": {
 			"version": "4.1.5",
@@ -21955,6 +21607,7 @@
 		},
 		"merge-stream": {
 			"version": "2.0.0",
+			"dev": true,
 			"peer": true
 		},
 		"merge2": {
@@ -22376,6 +22029,7 @@
 		},
 		"neo-async": {
 			"version": "2.6.2",
+			"dev": true,
 			"peer": true
 		},
 		"node-forge": {
@@ -22465,6 +22119,7 @@
 			"version": "2.0.6",
 			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.6.tgz",
 			"integrity": "sha512-PiVXnNuFm5+iYkLBNeq5211hvO38y63T0i2KKh2KnUs3RpzJ+JtODFjkD8yjLwnDkTYF1eKXheUwdssR+NRZdg==",
+			"dev": true,
 			"peer": true
 		},
 		"normalize-path": {
@@ -22490,12 +22145,6 @@
 			"requires": {
 				"boolbase": "~1.0.0"
 			}
-		},
-		"object-assign": {
-			"version": "4.1.1",
-			"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-			"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
-			"peer": true
 		},
 		"object-inspect": {
 			"version": "1.12.0",
@@ -22623,6 +22272,7 @@
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
 			"integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+			"dev": true,
 			"peer": true,
 			"requires": {
 				"yocto-queue": "^0.1.0"
@@ -22831,9 +22481,6 @@
 				}
 			}
 		},
-		"popper.js": {
-			"version": "1.16.1"
-		},
 		"postcss": {
 			"version": "8.4.18",
 			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.18.tgz",
@@ -23025,7 +22672,9 @@
 			}
 		},
 		"punycode": {
-			"version": "2.1.1"
+			"version": "2.1.1",
+			"dev": true,
+			"peer": true
 		},
 		"qs": {
 			"version": "6.11.0",
@@ -23067,6 +22716,7 @@
 		},
 		"randombytes": {
 			"version": "2.1.0",
+			"dev": true,
 			"peer": true,
 			"requires": {
 				"safe-buffer": "^5.1.0"
@@ -23110,27 +22760,6 @@
 					"dev": true,
 					"peer": true
 				}
-			}
-		},
-		"react": {
-			"version": "17.0.2",
-			"resolved": "https://registry.npmjs.org/react/-/react-17.0.2.tgz",
-			"integrity": "sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==",
-			"peer": true,
-			"requires": {
-				"loose-envify": "^1.1.0",
-				"object-assign": "^4.1.1"
-			}
-		},
-		"react-dom": {
-			"version": "17.0.2",
-			"resolved": "https://registry.npmjs.org/react-dom/-/react-dom-17.0.2.tgz",
-			"integrity": "sha512-s4h96KtLDUQlsENhMn1ar8t2bEa+q/YAtj8pPPdIjPDGBDIVNsrD9aXNWqspUe6AzKCIG0C1HZZLqLV7qpOBGA==",
-			"peer": true,
-			"requires": {
-				"loose-envify": "^1.1.0",
-				"object-assign": "^4.1.1",
-				"scheduler": "^0.20.2"
 			}
 		},
 		"readable-stream": {
@@ -23654,6 +23283,7 @@
 		},
 		"safe-buffer": {
 			"version": "5.1.2",
+			"dev": true,
 			"peer": true
 		},
 		"safer-buffer": {
@@ -23686,16 +23316,6 @@
 				"neo-async": "^2.6.2"
 			}
 		},
-		"scheduler": {
-			"version": "0.20.2",
-			"resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.20.2.tgz",
-			"integrity": "sha512-2eWfGgAqqWFGqtdMmcL5zCMK1U8KlXv8SQFGglL3CEtd0aDVDWgeF/YoCmvln55m5zSk3J/20hTaSBeSObsQDQ==",
-			"peer": true,
-			"requires": {
-				"loose-envify": "^1.1.0",
-				"object-assign": "^4.1.1"
-			}
-		},
 		"schema-utils": {
 			"version": "2.7.1",
 			"resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-2.7.1.tgz",
@@ -23707,9 +23327,6 @@
 				"ajv": "^6.12.4",
 				"ajv-keywords": "^3.5.2"
 			}
-		},
-		"scrollparent": {
-			"version": "2.0.1"
 		},
 		"select-hose": {
 			"version": "2.0.0",
@@ -23784,6 +23401,7 @@
 		},
 		"serialize-javascript": {
 			"version": "5.0.1",
+			"dev": true,
 			"peer": true,
 			"requires": {
 				"randombytes": "^2.1.0"
@@ -24006,6 +23624,7 @@
 			"version": "0.5.21",
 			"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
 			"integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
+			"dev": true,
 			"peer": true,
 			"requires": {
 				"buffer-from": "^1.0.0",
@@ -24229,6 +23848,8 @@
 			"version": "6.0.1",
 			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
 			"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+			"dev": true,
+			"peer": true,
 			"requires": {
 				"ansi-regex": "^5.0.1"
 			}
@@ -24634,12 +24255,14 @@
 			"version": "2.2.1",
 			"resolved": "https://registry.npmjs.org/tapable/-/tapable-2.2.1.tgz",
 			"integrity": "sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==",
+			"dev": true,
 			"peer": true
 		},
 		"terser": {
 			"version": "5.14.2",
 			"resolved": "https://registry.npmjs.org/terser/-/terser-5.14.2.tgz",
 			"integrity": "sha512-oL0rGeM/WFQCUd0y2QrWxYnq7tfSuKBiqTjRPWrRgB46WD/kiwHwF8T23z78H6Q6kGCuuHcPB+KULHRdxvVGQA==",
+			"dev": true,
 			"peer": true,
 			"requires": {
 				"@jridgewell/source-map": "^0.3.2",
@@ -24650,12 +24273,14 @@
 			"dependencies": {
 				"commander": {
 					"version": "2.20.3",
+					"dev": true,
 					"peer": true
 				}
 			}
 		},
 		"terser-webpack-plugin": {
 			"version": "5.1.3",
+			"dev": true,
 			"peer": true,
 			"requires": {
 				"jest-worker": "^27.0.2",
@@ -24668,6 +24293,7 @@
 			"dependencies": {
 				"schema-utils": {
 					"version": "3.0.0",
+					"dev": true,
 					"peer": true,
 					"requires": {
 						"@types/json-schema": "^7.0.6",
@@ -24970,6 +24596,7 @@
 			"version": "1.0.10",
 			"resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.10.tgz",
 			"integrity": "sha512-OztqDenkfFkbSG+tRxBeAnCVPckDBcvibKd35yDONx6OU8N7sqgwc7rCbkJ/WcYtVRZ4ba68d6byhC21GFh7sQ==",
+			"dev": true,
 			"peer": true,
 			"requires": {
 				"escalade": "^3.1.1",
@@ -24978,6 +24605,8 @@
 		},
 		"uri-js": {
 			"version": "4.2.2",
+			"dev": true,
+			"peer": true,
 			"requires": {
 				"punycode": "^2.1.0"
 			}
@@ -25050,23 +24679,6 @@
 			"version": "3.2.0",
 			"resolved": "https://registry.npmjs.org/v-click-outside/-/v-click-outside-3.2.0.tgz",
 			"integrity": "sha512-QD0bDy38SHJXQBjgnllmkI/rbdiwmq9RC+/+pvrFjYJKTn8dtp7Penf9q1lLBta280fYG2q53mgLhQ+3l3z74w=="
-		},
-		"v-tooltip": {
-			"version": "2.1.3",
-			"requires": {
-				"@babel/runtime": "^7.13.10",
-				"lodash": "^4.17.21",
-				"popper.js": "^1.16.1",
-				"vue-resize": "^1.0.1"
-			},
-			"dependencies": {
-				"vue-resize": {
-					"version": "1.0.1",
-					"requires": {
-						"@babel/runtime": "^7.13.10"
-					}
-				}
-			}
 		},
 		"v8-compile-cache": {
 			"version": "2.3.0",
@@ -25255,13 +24867,6 @@
 		"vue-multiselect": {
 			"version": "2.1.6"
 		},
-		"vue-observe-visibility": {
-			"version": "0.4.6"
-		},
-		"vue-resize": {
-			"version": "0.4.5",
-			"requires": {}
-		},
 		"vue-style-loader": {
 			"version": "4.1.3",
 			"resolved": "https://registry.npmjs.org/vue-style-loader/-/vue-style-loader-4.1.3.tgz",
@@ -25314,17 +24919,6 @@
 			"dev": true,
 			"peer": true
 		},
-		"vue-virtual-scroller": {
-			"version": "1.0.10",
-			"requires": {
-				"scrollparent": "^2.0.1",
-				"vue-observe-visibility": "^0.4.4",
-				"vue-resize": "^0.4.5"
-			}
-		},
-		"vue-visible": {
-			"version": "1.0.2"
-		},
 		"vue2-datepicker": {
 			"version": "3.11.0",
 			"resolved": "https://registry.npmjs.org/vue2-datepicker/-/vue2-datepicker-3.11.0.tgz",
@@ -25341,6 +24935,7 @@
 			"version": "2.4.0",
 			"resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.4.0.tgz",
 			"integrity": "sha512-Lcvm7MGST/4fup+ifyKi2hjyIAwcdI4HRgtvTpIUxBRhB+RFtUh8XtDOxUfctVCnhVi+QQj49i91OyvzkJl6cg==",
+			"dev": true,
 			"peer": true,
 			"requires": {
 				"glob-to-regexp": "^0.4.1",
@@ -25364,6 +24959,7 @@
 			"version": "5.74.0",
 			"resolved": "https://registry.npmjs.org/webpack/-/webpack-5.74.0.tgz",
 			"integrity": "sha512-A2InDwnhhGN4LYctJj6M1JEaGL7Luj6LOmyBHjcI8529cm5p6VXiTIW2sn6ffvEAKmveLzvu4jrihwXtPojlAA==",
+			"dev": true,
 			"peer": true,
 			"requires": {
 				"@types/eslint-scope": "^3.7.3",
@@ -25396,6 +24992,7 @@
 					"version": "1.8.0",
 					"resolved": "https://registry.npmjs.org/acorn-import-assertions/-/acorn-import-assertions-1.8.0.tgz",
 					"integrity": "sha512-m7VZ3jwz4eK6A4Vtt8Ew1/mNbP24u0FhdyfA7fSvnJR6LMdfOYnmuIrrJAgrYfYJ10F/otaHTtrtrtmHdMNzEw==",
+					"dev": true,
 					"peer": true,
 					"requires": {}
 				},
@@ -25403,6 +25000,7 @@
 					"version": "3.1.1",
 					"resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.1.1.tgz",
 					"integrity": "sha512-Y5PQxS4ITlC+EahLuXaY86TXfR7Dc5lw294alXOq86JAHCihAIZfqv8nNCWvaEJvaC51uN9hbLGeV0cFBdH+Fw==",
+					"dev": true,
 					"peer": true,
 					"requires": {
 						"@types/json-schema": "^7.0.8",
@@ -25590,6 +25188,7 @@
 			"version": "3.2.3",
 			"resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.2.3.tgz",
 			"integrity": "sha512-/DyMEOrDgLKKIG0fmvtz+4dUX/3Ghozwgm6iPp8KRhvn+eQf9+Q7GWxVNMk3+uCPWfdXYC4ExGBckIXdFEfH1w==",
+			"dev": true,
 			"peer": true
 		},
 		"websocket-driver": {
@@ -25721,6 +25320,7 @@
 		},
 		"yocto-queue": {
 			"version": "0.1.0",
+			"dev": true,
 			"peer": true
 		},
 		"zwitch": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
 				"@nextcloud/l10n": "^2.0.1",
 				"@nextcloud/moment": "^1.2.1",
 				"@nextcloud/router": "^2.0.1",
-				"@nextcloud/vue": "^7.5.0",
+				"@nextcloud/vue": "^7.6.0",
 				"@nextcloud/vue-dashboard": "^2.0.1",
 				"debounce": "^1.2.1",
 				"remark": "^14.0.2",
@@ -3095,9 +3095,9 @@
 			}
 		},
 		"node_modules/@nextcloud/vue": {
-			"version": "7.5.0",
-			"resolved": "https://registry.npmjs.org/@nextcloud/vue/-/vue-7.5.0.tgz",
-			"integrity": "sha512-XHGPGKcfRLGzXsKloW0W83v+3qB6qgazM1OGnX/Hk+j66Cxhb/Z/71Xi4y4zfWz65yT6Z6RRJKZB8Q4TiboEkw==",
+			"version": "7.6.0",
+			"resolved": "https://registry.npmjs.org/@nextcloud/vue/-/vue-7.6.0.tgz",
+			"integrity": "sha512-gTZO8zQGcObdKr8orkMBl/P9YpjfIOYdF76LUs+SdcZKFK+HGz5fBz8F4Xq/B7skDghcLqiZ6ixI+D08B6XhKA==",
 			"dependencies": {
 				"@floating-ui/dom": "^1.1.0",
 				"@nextcloud/auth": "^2.0.0",
@@ -3105,12 +3105,13 @@
 				"@nextcloud/browser-storage": "^0.2.0",
 				"@nextcloud/calendar-js": "^5.0.3",
 				"@nextcloud/capabilities": "^1.0.4",
-				"@nextcloud/dialogs": "^3.1.4",
+				"@nextcloud/dialogs": "^4.0.0",
 				"@nextcloud/event-bus": "^3.0.0",
 				"@nextcloud/initial-state": "^2.0.0",
-				"@nextcloud/l10n": "^1.6.0",
+				"@nextcloud/l10n": "^2.0.1",
 				"@nextcloud/logger": "^2.2.1",
 				"@nextcloud/router": "^2.0.0",
+				"@nextcloud/vue-select": "^3.21.2",
 				"@skjnldsv/sanitize-svg": "^1.0.2",
 				"debounce": "1.2.1",
 				"emoji-mart-vue-fast": "^12.0.1",
@@ -3129,7 +3130,6 @@
 				"vue-color": "^2.8.1",
 				"vue-material-design-icons": "^5.1.2",
 				"vue-multiselect": "^2.1.6",
-				"vue-select": "^3.20.2",
 				"vue2-datepicker": "^3.11.0"
 			},
 			"engines": {
@@ -3297,6 +3297,14 @@
 				"webpack": "^4.0.0 || ^5.0.0"
 			}
 		},
+		"node_modules/@nextcloud/vue-select": {
+			"version": "3.22.2",
+			"resolved": "https://registry.npmjs.org/@nextcloud/vue-select/-/vue-select-3.22.2.tgz",
+			"integrity": "sha512-nDtoFowunZIaiq5N28Qvbq2CkUWEbvLrj41OYQx8/qw7Dpmm2bOUKAqjUrr8H1NdoNpCN7VyL5gyoWvwC3m+WQ==",
+			"peerDependencies": {
+				"vue": "2.x"
+			}
+		},
 		"node_modules/@nextcloud/vue/node_modules/@floating-ui/core": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.1.0.tgz",
@@ -3322,6 +3330,30 @@
 				"npm": "^7.0.0 || ^8.0.0"
 			}
 		},
+		"node_modules/@nextcloud/vue/node_modules/@nextcloud/dialogs": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/@nextcloud/dialogs/-/dialogs-4.0.1.tgz",
+			"integrity": "sha512-jgIJdxTpc3suHkuZBRge6/dU6krG7x9emMGTxKY5qRQqFwn9r4rCqjV7Cys7VMn1QLlHmEDdqHcYZFRtN/XVNA==",
+			"dependencies": {
+				"@nextcloud/l10n": "^1.3.0",
+				"@nextcloud/typings": "^1.4.3",
+				"core-js": "^3.6.4",
+				"toastify-js": "^1.12.0"
+			},
+			"engines": {
+				"node": "^16.0.0",
+				"npm": "^7.0.0 || ^8.0.0"
+			}
+		},
+		"node_modules/@nextcloud/vue/node_modules/@nextcloud/dialogs/node_modules/@nextcloud/l10n": {
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/@nextcloud/l10n/-/l10n-1.6.0.tgz",
+			"integrity": "sha512-aKGlgrwN9OiafN791sYus0shfwNeU3PlrH6Oi9ISma6iJSvN6a8aJM8WGKCJ9pqBaTR5PrDuckuM/WnybBWb6A==",
+			"dependencies": {
+				"core-js": "^3.6.4",
+				"node-gettext": "^3.0.0"
+			}
+		},
 		"node_modules/@nextcloud/vue/node_modules/@nextcloud/event-bus": {
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/@nextcloud/event-bus/-/event-bus-3.0.2.tgz",
@@ -3334,14 +3366,22 @@
 				"npm": "^7.0.0 || ^8.0.0"
 			}
 		},
-		"node_modules/@nextcloud/vue/node_modules/@nextcloud/l10n": {
+		"node_modules/@nextcloud/vue/node_modules/@nextcloud/typings": {
 			"version": "1.6.0",
-			"resolved": "https://registry.npmjs.org/@nextcloud/l10n/-/l10n-1.6.0.tgz",
-			"integrity": "sha512-aKGlgrwN9OiafN791sYus0shfwNeU3PlrH6Oi9ISma6iJSvN6a8aJM8WGKCJ9pqBaTR5PrDuckuM/WnybBWb6A==",
+			"resolved": "https://registry.npmjs.org/@nextcloud/typings/-/typings-1.6.0.tgz",
+			"integrity": "sha512-5uIsteFy9Z9/ZaNGE8w8SDgJp+FK8/LeRLgfnakC2pU8eNKTPlQfkiYR163oEI5Xu5YzwdIzf6/roIXdNinhrw==",
 			"dependencies": {
-				"core-js": "^3.6.4",
-				"node-gettext": "^3.0.0"
+				"@types/jquery": "2.0.60"
+			},
+			"engines": {
+				"node": "^16.0.0",
+				"npm": "^7.0.0 || ^8.0.0"
 			}
+		},
+		"node_modules/@nextcloud/vue/node_modules/@types/jquery": {
+			"version": "2.0.60",
+			"resolved": "https://registry.npmjs.org/@types/jquery/-/jquery-2.0.60.tgz",
+			"integrity": "sha512-izi6OBEVrAwaHiqWITjOPBbVtcKZKAXTocJqPZsAKA2lvmbpFEyPSAxgcqmisbiMYj9EvrooUEPLHQeQqVMWAg=="
 		},
 		"node_modules/@nextcloud/vue/node_modules/emoji-mart-vue-fast": {
 			"version": "12.0.1",
@@ -14269,14 +14309,6 @@
 				"vue": "^2.3.0"
 			}
 		},
-		"node_modules/vue-select": {
-			"version": "3.20.2",
-			"resolved": "https://registry.npmjs.org/vue-select/-/vue-select-3.20.2.tgz",
-			"integrity": "sha512-ZSzIDzyYsWZULGUxVp1h6u3yi9IZQBWX8r6kSudUI/I5J1HQKpBjRntvkrg6pr87xmm16kdChvHCDN+W84vTKw==",
-			"peerDependencies": {
-				"vue": "2.x"
-			}
-		},
 		"node_modules/vue-style-loader": {
 			"version": "4.1.3",
 			"resolved": "https://registry.npmjs.org/vue-style-loader/-/vue-style-loader-4.1.3.tgz",
@@ -17073,9 +17105,9 @@
 			}
 		},
 		"@nextcloud/vue": {
-			"version": "7.5.0",
-			"resolved": "https://registry.npmjs.org/@nextcloud/vue/-/vue-7.5.0.tgz",
-			"integrity": "sha512-XHGPGKcfRLGzXsKloW0W83v+3qB6qgazM1OGnX/Hk+j66Cxhb/Z/71Xi4y4zfWz65yT6Z6RRJKZB8Q4TiboEkw==",
+			"version": "7.6.0",
+			"resolved": "https://registry.npmjs.org/@nextcloud/vue/-/vue-7.6.0.tgz",
+			"integrity": "sha512-gTZO8zQGcObdKr8orkMBl/P9YpjfIOYdF76LUs+SdcZKFK+HGz5fBz8F4Xq/B7skDghcLqiZ6ixI+D08B6XhKA==",
 			"requires": {
 				"@floating-ui/dom": "^1.1.0",
 				"@nextcloud/auth": "^2.0.0",
@@ -17083,12 +17115,13 @@
 				"@nextcloud/browser-storage": "^0.2.0",
 				"@nextcloud/calendar-js": "^5.0.3",
 				"@nextcloud/capabilities": "^1.0.4",
-				"@nextcloud/dialogs": "^3.1.4",
+				"@nextcloud/dialogs": "^4.0.0",
 				"@nextcloud/event-bus": "^3.0.0",
 				"@nextcloud/initial-state": "^2.0.0",
-				"@nextcloud/l10n": "^1.6.0",
+				"@nextcloud/l10n": "^2.0.1",
 				"@nextcloud/logger": "^2.2.1",
 				"@nextcloud/router": "^2.0.0",
+				"@nextcloud/vue-select": "^3.21.2",
 				"@skjnldsv/sanitize-svg": "^1.0.2",
 				"debounce": "1.2.1",
 				"emoji-mart-vue-fast": "^12.0.1",
@@ -17107,7 +17140,6 @@
 				"vue-color": "^2.8.1",
 				"vue-material-design-icons": "^5.1.2",
 				"vue-multiselect": "^2.1.6",
-				"vue-select": "^3.20.2",
 				"vue2-datepicker": "^3.11.0"
 			},
 			"dependencies": {
@@ -17132,6 +17164,28 @@
 						"core-js": "3.25.5"
 					}
 				},
+				"@nextcloud/dialogs": {
+					"version": "4.0.1",
+					"resolved": "https://registry.npmjs.org/@nextcloud/dialogs/-/dialogs-4.0.1.tgz",
+					"integrity": "sha512-jgIJdxTpc3suHkuZBRge6/dU6krG7x9emMGTxKY5qRQqFwn9r4rCqjV7Cys7VMn1QLlHmEDdqHcYZFRtN/XVNA==",
+					"requires": {
+						"@nextcloud/l10n": "^1.3.0",
+						"@nextcloud/typings": "^1.4.3",
+						"core-js": "^3.6.4",
+						"toastify-js": "^1.12.0"
+					},
+					"dependencies": {
+						"@nextcloud/l10n": {
+							"version": "1.6.0",
+							"resolved": "https://registry.npmjs.org/@nextcloud/l10n/-/l10n-1.6.0.tgz",
+							"integrity": "sha512-aKGlgrwN9OiafN791sYus0shfwNeU3PlrH6Oi9ISma6iJSvN6a8aJM8WGKCJ9pqBaTR5PrDuckuM/WnybBWb6A==",
+							"requires": {
+								"core-js": "^3.6.4",
+								"node-gettext": "^3.0.0"
+							}
+						}
+					}
+				},
 				"@nextcloud/event-bus": {
 					"version": "3.0.2",
 					"resolved": "https://registry.npmjs.org/@nextcloud/event-bus/-/event-bus-3.0.2.tgz",
@@ -17140,14 +17194,18 @@
 						"semver": "^7.3.7"
 					}
 				},
-				"@nextcloud/l10n": {
+				"@nextcloud/typings": {
 					"version": "1.6.0",
-					"resolved": "https://registry.npmjs.org/@nextcloud/l10n/-/l10n-1.6.0.tgz",
-					"integrity": "sha512-aKGlgrwN9OiafN791sYus0shfwNeU3PlrH6Oi9ISma6iJSvN6a8aJM8WGKCJ9pqBaTR5PrDuckuM/WnybBWb6A==",
+					"resolved": "https://registry.npmjs.org/@nextcloud/typings/-/typings-1.6.0.tgz",
+					"integrity": "sha512-5uIsteFy9Z9/ZaNGE8w8SDgJp+FK8/LeRLgfnakC2pU8eNKTPlQfkiYR163oEI5Xu5YzwdIzf6/roIXdNinhrw==",
 					"requires": {
-						"core-js": "^3.6.4",
-						"node-gettext": "^3.0.0"
+						"@types/jquery": "2.0.60"
 					}
+				},
+				"@types/jquery": {
+					"version": "2.0.60",
+					"resolved": "https://registry.npmjs.org/@types/jquery/-/jquery-2.0.60.tgz",
+					"integrity": "sha512-izi6OBEVrAwaHiqWITjOPBbVtcKZKAXTocJqPZsAKA2lvmbpFEyPSAxgcqmisbiMYj9EvrooUEPLHQeQqVMWAg=="
 				},
 				"emoji-mart-vue-fast": {
 					"version": "12.0.1",
@@ -17279,6 +17337,12 @@
 					}
 				}
 			}
+		},
+		"@nextcloud/vue-select": {
+			"version": "3.22.2",
+			"resolved": "https://registry.npmjs.org/@nextcloud/vue-select/-/vue-select-3.22.2.tgz",
+			"integrity": "sha512-nDtoFowunZIaiq5N28Qvbq2CkUWEbvLrj41OYQx8/qw7Dpmm2bOUKAqjUrr8H1NdoNpCN7VyL5gyoWvwC3m+WQ==",
+			"requires": {}
 		},
 		"@nextcloud/webpack-vue-config": {
 			"version": "5.4.0",
@@ -25196,12 +25260,6 @@
 		},
 		"vue-resize": {
 			"version": "0.4.5",
-			"requires": {}
-		},
-		"vue-select": {
-			"version": "3.20.2",
-			"resolved": "https://registry.npmjs.org/vue-select/-/vue-select-3.20.2.tgz",
-			"integrity": "sha512-ZSzIDzyYsWZULGUxVp1h6u3yi9IZQBWX8r6kSudUI/I5J1HQKpBjRntvkrg6pr87xmm16kdChvHCDN+W84vTKw==",
 			"requires": {}
 		},
 		"vue-style-loader": {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
 		"@nextcloud/moment": "^1.2.1",
 		"@nextcloud/router": "^2.0.1",
 		"@nextcloud/vue": "^7.6.0",
-		"@nextcloud/vue-dashboard": "^2.0.1",
 		"debounce": "^1.2.1",
 		"remark": "^14.0.2",
 		"strip-markdown": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
 		"npm": "^7.0.0 || ^8.0.0"
 	},
 	"dependencies": {
-		"@juliushaertl/vue-richtext": "^1.0.1",
 		"@nextcloud/auth": "^2.0.0",
 		"@nextcloud/axios": "^2.3.0",
 		"@nextcloud/dialogs": "^3.2.0",
@@ -30,6 +29,7 @@
 		"@nextcloud/moment": "^1.2.1",
 		"@nextcloud/router": "^2.0.1",
 		"@nextcloud/vue": "^7.6.0",
+		"@nextcloud/vue-richtext": "^2.1.0-beta.5",
 		"debounce": "^1.2.1",
 		"remark": "^14.0.2",
 		"strip-markdown": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
 		"@nextcloud/l10n": "^2.0.1",
 		"@nextcloud/moment": "^1.2.1",
 		"@nextcloud/router": "^2.0.1",
-		"@nextcloud/vue": "^7.5.0",
+		"@nextcloud/vue": "^7.6.0",
 		"@nextcloud/vue-dashboard": "^2.0.1",
 		"debounce": "^1.2.1",
 		"remark": "^14.0.2",

--- a/src/Components/Announcement.vue
+++ b/src/Components/Announcement.vue
@@ -89,7 +89,7 @@
 </template>
 
 <script>
-import RichText from '@juliushaertl/vue-richtext'
+import { RichText } from '@nextcloud/vue-richtext'
 import NcActions from '@nextcloud/vue/dist/Components/NcActions.js'
 import NcActionButton from '@nextcloud/vue/dist/Components/NcActionButton.js'
 import NcAvatar from '@nextcloud/vue/dist/Components/NcAvatar.js'

--- a/src/main.js
+++ b/src/main.js
@@ -30,7 +30,7 @@ import Vuex from 'vuex'
 
 // Styles
 import '@nextcloud/dialogs/styles/toast.scss'
-import '@juliushaertl/vue-richtext/dist/vue-richtext.scss'
+import '@nextcloud/vue-richtext/dist/style.css'
 
 // eslint-disable-next-line
 __webpack_nonce__ = btoa(getRequestToken())

--- a/src/views/Dashboard.vue
+++ b/src/views/Dashboard.vue
@@ -20,30 +20,37 @@
   -->
 
 <template>
-	<DashboardWidget id="announcementcenter_panel"
+	<NcDashboardWidget id="announcementcenter_panel"
 		:items="items"
 		:loading="loading"
 		empty-content-icon="icon-announcementcenter-dark"
-		:empty-content-message="t('announcementcenter', 'No announcements')" />
+		:empty-content-message="t('announcementcenter', 'No announcements')">
+		<template #emptyContentIcon>
+			<div class="icon-announcementcenter-dark" />
+		</template>
+	</NcDashboardWidget>
 </template>
 
 <script>
-import { DashboardWidget } from '@nextcloud/vue-dashboard'
+import NcDashboardWidget from '@nextcloud/vue/dist/Components/NcDashboardWidget.js'
 import { loadState } from '@nextcloud/initial-state'
 import { generateUrl, imagePath } from '@nextcloud/router'
 import moment from '@nextcloud/moment'
 
 export default {
 	name: 'Dashboard',
+
 	components: {
-		DashboardWidget,
+		NcDashboardWidget,
 	},
+
 	data() {
 		return {
 			announcements: [],
 			loading: true,
 		}
 	},
+
 	computed: {
 		items() {
 			return this.announcements.map((item) => {
@@ -60,6 +67,7 @@ export default {
 			})
 		},
 	},
+
 	mounted() {
 		try {
 			this.announcements = loadState('announcementcenter', 'announcementcenter_dashboard')
@@ -70,3 +78,11 @@ export default {
 	},
 }
 </script>
+
+<style lang="scss" scoped>
+.icon-announcementcenter-dark {
+	background-size: 64px;
+	width: 64px;
+	height: 64px;
+}
+</style>


### PR DESCRIPTION
### Added
- Compatibility with Nextcloud 26

### Changed
- Updated and migrated some dependencies

### Fixed
- Don't load comment sidebar when the active announcement doesn't allow comments  [#576](https://github.com/nextcloud/announcementcenter/pull/576)
- Log announcement creation and deletion  [#571](https://github.com/nextcloud/announcementcenter/pull/571)
- Skip users without a valid email address  [#551](https://github.com/nextcloud/announcementcenter/pull/551)