### PR TITLE
chore(release): Bump version to 6.5.1 and add changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## 6.5.1 – 2023-03-01
+### Changed
+- Updated some dependencies
+
+### Fixed
+- Fix broken group selection with `@nextcloud/vue` update
+  [#607](https://github.com/nextcloud/announcementcenter/pull/607)
+
 ## 6.5.0 – 2023-02-16
 ### Added
 - Compatibility with Nextcloud 26

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -17,7 +17,7 @@
 ⚡ Activities integration
 
 🔔 Notifications integration]]></description>
-	<version>6.5.0</version>
+	<version>6.5.1</version>
 	<licence>agpl</licence>
 	<author>Joas Schilling</author>
 	<namespace>AnnouncementCenter</namespace>


### PR DESCRIPTION
### Changed
- Updated some dependencies

### Fixed
- Fix broken group selection with `@nextcloud/vue` update [#607](https://github.com/nextcloud/announcementcenter/pull/607)