### PR TITLE
Move group selection up as first action so more options are visible

### DIFF
--- a/src/Components/NewForm.vue
+++ b/src/Components/NewForm.vue
@@ -43,6 +43,18 @@
 			</NcButton>
 
 			<NcActions>
+				<NcActionInput v-model="groups"
+					icon="icon-group"
+					type="multiselect"
+					:options="groupOptions"
+					label="label"
+					track-by="id"
+					:multiple="true"
+					:placeholder="t('announcementcenter', 'Everyone')"
+					:title="t('announcementcenter', 'These groups will be able to see the announcement. If no group is selected, all users can see it.')"
+					@search-change="onSearchChanged">
+					{{ t('announcementcenter', 'Everyone') }}
+				</NcActionInput>
 				<NcActionCheckbox value="1"
 					:checked.sync="createActivities">
 					{{ t('announcementcenter', 'Create activities') }}
@@ -59,18 +71,6 @@
 					:checked.sync="allowComments">
 					{{ t('announcementcenter', 'Allow comments') }}
 				</NcActionCheckbox>
-				<NcActionInput v-model="groups"
-					icon="icon-group"
-					type="multiselect"
-					:options="groupOptions"
-					label="label"
-					track-by="id"
-					:multiple="true"
-					:placeholder="t('announcementcenter', 'Everyone')"
-					:title="t('announcementcenter', 'These groups will be able to see the announcement. If no group is selected, all users can see it.')"
-					@search-change="onSearchChanged">
-					{{ t('announcementcenter', 'Everyone') }}
-				</NcActionInput>
 			</NcActions>
 		</div>
 	</div>


### PR DESCRIPTION
Adjusting the groups selection to the top of the popup.

It has been crippled, since its at the bottom of the popup.  You can no longer search groups properly and the popup does not work on the CHROME browser.  So moving it to the top of the popup doesn't hide all the searched groups.  When keeping the dropdown at the bottom of the popup, you lose the ability to search the groups.

1. To recreate this problem, you simply go to the announcement center and try to type in a group.
2. Popup borders restrict and limit the selection of the dropdown menu, disabling your ability to actually select a group.
3. Moving the dropdown to the top of the popup allows for this dropdown to function correctly.