### PR TITLE
Update APIController.php

### DIFF
--- a/lib/Controller/APIController.php
+++ b/lib/Controller/APIController.php
@@ -239,7 +239,7 @@ class APIController extends OCSController {
 			);
 		}
 
-		$groups = $this->groupManager->search($search, 25);
+		$groups = $this->groupManager->search($search, 50);
 		$results = [];
 		foreach ($groups as $group) {
 			$results[] = [


### PR DESCRIPTION
changing 25 to 50.

Searching for these groups doesn't seem to actually work.  Whether its the 25 that breaks this or the search that doesn't work on the group manager, I am unsure.

Placing this limitation of 25 on this, doesn't show more than 25 groups ever.  As the search in the box doesn't make a round trip to the server.  We need this increased to 50 to at least allow 50 groups to be shown on the drop down.  

We presently have 36 groups inside of our installation.  I don't believe we will hit 50.