### PR TITLE
Add CLI command to remove notifications from an announcement

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -52,6 +52,7 @@
 		<command>OCA\AnnouncementCenter\Command\Announce</command>
 		<command>OCA\AnnouncementCenter\Command\AnnouncementList</command>
 		<command>OCA\AnnouncementCenter\Command\AnnouncementDelete</command>
+		<command>OCA\AnnouncementCenter\Command\RemoveNotifications</command>
 	</commands>
 
 	<settings>

--- a/lib/Command/RemoveNotifications.php
+++ b/lib/Command/RemoveNotifications.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @copyright Copyright (c) 2024 Marvin Winkens <m.winkens@fz-juelich.de>
+ *
+ * @author Marvin Winkens <m.winkens@fz-juelich.de>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+namespace OCA\AnnouncementCenter\Command;
+
+use InvalidArgumentException;
+use OCA\AnnouncementCenter\Manager;
+use OCA\AnnouncementCenter\Model\AnnouncementDoesNotExistException;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class RemoveNotifications extends Command {
+	public function __construct(
+		protected Manager $manager,
+		protected LoggerInterface $logger,
+	) {
+		parent::__construct();
+	}
+
+	protected function configure(): void {
+		$this
+			->setName('announcementcenter:remove-notifications')  # others use minus sign as well
+			->setDescription('Remove notifications of announcement by id')
+			->addArgument(
+				'id',
+				InputArgument::REQUIRED,
+				'Id of announcement to remove notifications from',
+			);
+	}
+
+	protected function execute(InputInterface $input, OutputInterface $output): int {
+		try {
+			$removeNotId = $this->parseId($input->getArgument('id'));
+			$this->manager->getAnnouncement($removeNotId, true);
+			$this->manager->removeNotifications($removeNotId);
+		} catch (AnnouncementDoesNotExistException) {
+			$output->writeln('Announcement with #' . $removeNotId . ' does not exist!');
+			return 1;
+		} catch (InvalidArgumentException $e) {
+			$output->writeln($e->getMessage());
+			return 1;
+		}
+		$output->writeln('Successfully removed notifications from accouncement #' . $removeNotId);
+		$this->logger->info('Admin removed notifications from announcement #' . $removeNotId . ' over CLI');
+		return 0;
+	}
+
+	private function parseId(mixed $value) {
+		if (is_numeric($value)) {
+			return (int)$value;
+		}
+		throw new InvalidArgumentException('Id "' . $value . '" is not an integer');
+	}
+}

--- a/tests/Command/RemoveNotificationsTest.php
+++ b/tests/Command/RemoveNotificationsTest.php
@@ -1,0 +1,116 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * @copyright Copyright (c) 2024 Marvin Winkens <m.winkens@fz-juelich.de>
+ *
+ * @author Marvin Winkens <m.winkens@fz-juelich.de>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+namespace OCA\AnnouncementCenter\Tests\Command;
+
+use OCA\AnnouncementCenter\Command\RemoveNotifications;
+use OCA\AnnouncementCenter\Manager;
+use OCA\AnnouncementCenter\Model\AnnouncementDoesNotExistException;
+use OCA\AnnouncementCenter\Tests\TestCase;
+use PHPUnit\Framework\MockObject\MockObject;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class RemoveNotificationsTest extends TestCase {
+	protected Manager|MockObject $manager;
+	protected LoggerInterface|MockObject $logger;
+	protected Command $removeNotificationsCommand;
+	protected InputInterface|MockObject $input;
+	protected OutputInterface|MockObject $output;
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->manager = $this->createMock(Manager::class);
+		$this->logger = $this->createMock(LoggerInterface::class);
+
+		$this->input = $this->getMockBuilder(InputInterface::class)
+			->setMethods([
+				'getArgument',
+				'getOption',
+				'getFirstArgument',
+				'hasParameterOption',
+				'getParameterOption',
+				'bind',
+				'validate',
+				'getArguments',
+				'setArgument',
+				'hasArgument',
+				'getOptions',
+				'isInteractive',
+				'hasOption',
+				'setOption',
+				'setInteractive',
+			])
+			->getMock();
+		$this->output = $this->createMock(OutputInterface::class);
+
+		$this->removeNotificationsCommand = new RemoveNotifications(
+			$this->manager,
+			$this->logger,
+		);
+	}
+
+	public function testRemoveNotificationsSuccessfully() {
+		$this->input->expects($this->once())
+			->method('getArgument')
+			->with('id')
+			->willReturn(42);
+		$this->manager->expects($this->once())
+			->method('removeNotifications');
+		$this->manager->expects($this->once())
+			->method('getAnnouncement');
+		$this->output->expects($this->atLeastOnce())
+			->method('writeln');
+		$this->logger->expects($this->atLeastOnce())
+			->method('info');
+		$result = self::invokePrivate($this->removeNotificationsCommand, 'execute', [$this->input, $this->output]);
+		self::assertEquals(0, $result);
+	}
+
+	public function testRemoveNotificationsInvalidId() {
+		$this->input->expects($this->once())
+			->method('getArgument')
+			->with('id')
+			->willReturn('invalid');
+		$result = self::invokePrivate($this->removeNotificationsCommand, 'execute', [$this->input, $this->output]);
+		self::assertEquals(true, $result > 0);
+	}
+
+	public function testRemoveNotificationsDoesNotExist() {
+		$this->input->expects($this->once())
+			->method('getArgument')
+			->with('id')
+			->willReturn(42);
+		$this->manager->expects($this->once())
+			->method('getAnnouncement')
+			->willThrowException(new AnnouncementDoesNotExistException('message'));
+		$this->output->expects($this->atLeastOnce())
+			->method('writeln');
+		$result = self::invokePrivate($this->removeNotificationsCommand, 'execute', [$this->input, $this->output]);
+		self::assertEquals(true, $result > 0);
+	}
+}


### PR DESCRIPTION
closes #839

## Help

```
$ php occ announcementcenter:remove-notifications --help
Description:
  Remove notifications of announcement by id

Usage:
  announcementcenter:remove-notifications <id>

Arguments:
  id                    Id of announcement to remove notifications from

Options:
  -h, --help            Display help for the given command. When no command is given display help for the list command
  -q, --quiet           Do not output any message
  -V, --version         Display this application version
      --ansi|--no-ansi  Force (or disable --no-ansi) ANSI output
  -n, --no-interaction  Do not ask any interactive question
      --no-warnings     Skip global warnings, show command output only
  -v|vv|vvv, --verbose  Increase the verbosity of messages: 1 for normal output, 2 for more verbose output and 3 for debug
```

## Guide
- list announcements:

```
$ php occ announcementcenter:list
ID  |Subject                 |Message                                           
----|------------------------|--------------------------------------------------
70  |test21                  |test21                                            
69  |test20                  |test20 linebreak                                  
68  |test19                  |test19                                            
60  |test17                  |test17                                            
59  |test16                  |test16                                            
58  |test15                  |test15                                            
57  |test14                  |test14                                            
56  |test13                  |test13                                            
55  |test12                  |test12                                            
51  |test9                   |test9                                             
And more ...
```

- remove notifications by ID:

```
$ php occ announcementcenter:remove-notifications 70
Successfully removed notifications from accouncement #70
```

## Roadmap

- [x] Tests
- [x] Manual tests
