### PR TITLE
Move scheduling and deletion into `...` menu

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "remark": "^15.0.1",
         "strip-markdown": "^6.0.0",
         "vue": "^2.7.16",
+        "vue-material-design-icons": "^5.3.0",
         "vuex": "^3.6.2"
       },
       "devDependencies": {
@@ -14739,6 +14740,12 @@
         }
       }
     },
+    "node_modules/vue-material-design-icons": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/vue-material-design-icons/-/vue-material-design-icons-5.3.0.tgz",
+      "integrity": "sha512-wnbRh+48RwX/Gt+iqwCSdWpm0hPBwwv9F7MSouUzZ2PsphYVMJB9KkG9iGs+tgBiT57ZiurFEK07Y/rFKx+Ekg==",
+      "license": "MIT"
+    },
     "node_modules/vue-router": {
       "version": "3.6.5",
       "resolved": "https://registry.npmjs.org/vue-router/-/vue-router-3.6.5.tgz",
@@ -26014,6 +26021,11 @@
         "vue-hot-reload-api": "^2.3.0",
         "vue-style-loader": "^4.1.0"
       }
+    },
+    "vue-material-design-icons": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/vue-material-design-icons/-/vue-material-design-icons-5.3.0.tgz",
+      "integrity": "sha512-wnbRh+48RwX/Gt+iqwCSdWpm0hPBwwv9F7MSouUzZ2PsphYVMJB9KkG9iGs+tgBiT57ZiurFEK07Y/rFKx+Ekg=="
     },
     "vue-router": {
       "version": "3.6.5",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "remark": "^15.0.1",
     "strip-markdown": "^6.0.0",
     "vue": "^2.7.16",
+    "vue-material-design-icons": "^5.3.0",
     "vuex": "^3.6.2"
   },
   "devDependencies": {

--- a/src/Components/NewForm.vue
+++ b/src/Components/NewForm.vue
@@ -43,18 +43,6 @@
 			</NcButton>
 
 			<NcActions>
-				<NcActionInput v-model="groups"
-					icon="icon-group"
-					type="multiselect"
-					:options="groupOptions"
-					track-by="id"
-					:multiple="true"
-					:input-label="t('announcementcenter', 'Visibility')"
-					:placeholder="t('announcementcenter', 'Everyone')"
-					:title="t('announcementcenter', 'These groups will be able to see the announcement. If no group is selected, all users can see it.')"
-					@search="onSearchChanged">
-					{{ t('announcementcenter', 'Everyone') }}
-				</NcActionInput>
 				<NcActionCheckbox value="1"
 					:checked.sync="createActivities">
 					{{ t('announcementcenter', 'Create activities') }}
@@ -71,6 +59,19 @@
 					:checked.sync="allowComments">
 					{{ t('announcementcenter', 'Allow comments') }}
 				</NcActionCheckbox>
+				<NcActionSeparator />
+				<NcActionInput v-model="groups"
+					icon="icon-group"
+					type="multiselect"
+					:options="groupOptions"
+					track-by="id"
+					:multiple="true"
+					:input-label="t('announcementcenter', 'Visibility')"
+					:placeholder="t('announcementcenter', 'Everyone')"
+					:title="t('announcementcenter', 'These groups will be able to see the announcement. If no group is selected, all users can see it.')"
+					@search="onSearchChanged">
+					{{ t('announcementcenter', 'Everyone') }}
+				</NcActionInput>
 				<NcActionSeparator />
 				<NcActionInput type="datetime-local"
 					:label="t('announcementcenter', 'Schedule announcement time')"

--- a/src/Components/NewForm.vue
+++ b/src/Components/NewForm.vue
@@ -35,31 +35,6 @@
 			rows="4"
 			:placeholder="t('announcementcenter', 'Write announcement text, Markdown can be used …')" />
 
-		<div class="announcement__form__schedule">
-			<NcCheckboxRadioSwitch :checked.sync="scheduleEnabled">
-				{{ t('announcementcenter', 'Schedule announcement time (optional)') }}
-			</NcCheckboxRadioSwitch>
-			<NcDateTimePicker v-model="scheduleTime"
-				:disabled="!scheduleEnabled"
-				:clearable="true"
-				:disabled-date="disabledInPastDate"
-				:disabled-time="disabledInPastTime"
-				:show-second="false"
-				type="datetime" />
-		</div>
-		<div class="announcement__form__delete">
-			<NcCheckboxRadioSwitch :checked.sync="deleteEnabled">
-				{{ t('announcementcenter', 'Schedule deletion time (optional)') }}
-			</NcCheckboxRadioSwitch>
-			<NcDateTimePicker v-model="deleteTime"
-				:disabled="!deleteEnabled"
-				:clearable="true"
-				:disabled-date="disabledInPastDate"
-				:disabled-time="disabledInPastTime"
-				:show-second="false"
-				type="datetime" />
-		</div>
-
 		<div class="announcement__form__buttons">
 			<NcButton type="primary"
 				:disabled="!subject"
@@ -96,6 +71,32 @@
 					:checked.sync="allowComments">
 					{{ t('announcementcenter', 'Allow comments') }}
 				</NcActionCheckbox>
+				<NcActionSeparator />
+				<NcActionCheckbox value="0"
+					:checked.sync="scheduleEnabled">
+					{{ t('announcementcenter', 'Schedule announcement time (optional)') }}
+				</NcActionCheckbox>
+				<NcDateTimePicker v-model="scheduleTime"
+					class="announcement__form__timepicker"
+					:disabled="!scheduleEnabled"
+					:clearable="true"
+					:disabled-date="disabledInPastDate"
+					:disabled-time="disabledInPastTime"
+					:show-second="false"
+					type="datetime" />
+				<NcActionSeparator />
+				<NcActionCheckbox value="0"
+					:checked.sync="deleteEnabled">
+					{{ t('announcementcenter', 'Schedule deletion time (optional)') }}
+				</NcActionCheckbox>
+				<NcDateTimePicker v-model="deleteTime"
+					class="announcement__form__timepicker"
+					:disabled="!deleteEnabled"
+					:clearable="true"
+					:disabled-date="disabledInPastDate"
+					:disabled-time="disabledInPastTime"
+					:show-second="false"
+					type="datetime" />
 			</NcActions>
 		</div>
 	</div>
@@ -105,8 +106,8 @@
 import NcActions from '@nextcloud/vue/dist/Components/NcActions.js'
 import NcActionCheckbox from '@nextcloud/vue/dist/Components/NcActionCheckbox.js'
 import NcActionInput from '@nextcloud/vue/dist/Components/NcActionInput.js'
+import NcActionSeparator from '@nextcloud/vue/dist/Components/NcActionSeparator.js'
 import NcDateTimePicker from '@nextcloud/vue/dist/Components/NcDateTimePicker.js'
-import NcCheckboxRadioSwitch from '@nextcloud/vue/dist/Components/NcCheckboxRadioSwitch.js'
 import NcButton from '@nextcloud/vue/dist/Components/NcButton.js'
 import debounce from 'debounce'
 import { loadState } from '@nextcloud/initial-state'
@@ -125,8 +126,8 @@ export default {
 		NcActions,
 		NcActionCheckbox,
 		NcActionInput,
+		NcActionSeparator,
 		NcDateTimePicker,
-		NcCheckboxRadioSwitch,
 		NcButton,
 	},
 
@@ -249,10 +250,8 @@ export default {
 		}
 	}
 
-	&__delete,
-	&__schedule {
-		display: flex;
-		justify-content: space-between;
+	&__timepicker {
+		width: 100%;
 	}
 }
 </style>

--- a/src/Components/NewForm.vue
+++ b/src/Components/NewForm.vue
@@ -170,17 +170,6 @@ export default {
 			this.deleteTime = null
 		},
 
-		disabledInPastDate(date) {
-			const today = new Date()
-			today.setHours(0, 0, 0, 0)
-			return date < today
-		},
-
-		disabledInPastTime(date) {
-			const today = new Date()
-			return date < today
-		},
-
 		onSearchChanged: debounce(function(search) {
 			this.searchGroups(search)
 		}, 300),

--- a/src/Components/NewForm.vue
+++ b/src/Components/NewForm.vue
@@ -75,7 +75,8 @@
 				<NcActionInput type="datetime-local"
 					:label="t('announcementcenter', 'Schedule announcement time')"
 					:disabled="!scheduleEnabled"
-					:is-native-picker="true"
+					is-native-picker
+					hide-label
 					:value="scheduleTime"
 					:min="new Date()"
 					@change="setScheduleTime">
@@ -87,7 +88,8 @@
 				<NcActionInput type="datetime-local"
 					:label="t('announcementcenter', 'Schedule deletion time')"
 					:disabled="!deleteEnabled"
-					:is-native-picker="true"
+					is-native-picker
+					hide-label
 					:value="deleteTime"
 					:min="getMinDeleteTime()"
 					id-native-date-time-picker="date-time-picker-delete_id"


### PR DESCRIPTION
closes #820
closes #846 (for some reason)

This was the best I was able to come up with for now. I think it's not too bad with the separators.
@nickvergessen I don't know how to handle the translations, I would remove the `(optional)` part here.

![Bildschirmfoto vom 2024-09-24 15-14-12](https://github.com/user-attachments/assets/850c165f-af73-4eb3-b721-adb6148630ff)

