### PR TITLE
fix `invalid date` bug for scheduled announcements

### DIFF
--- a/src/Components/Announcement.vue
+++ b/src/Components/Announcement.vue
@@ -36,6 +36,8 @@
 					{{ author }}
 					·
 					<span v-if="isScheduled"
+						class="live-relative-timestamp"
+						:data-timestamp="scheduleTime * 1000"
 						:title="scheduledLabel">{{ scheduledLabel }}</span>
 					<span v-else
 						class="live-relative-timestamp"

--- a/src/Components/Announcement.vue
+++ b/src/Components/Announcement.vue
@@ -36,7 +36,6 @@
 					{{ author }}
 					·
 					<span v-if="isScheduled"
-						class="live-relative-timestamp"
 						:title="scheduledLabel">{{ scheduledLabel }}</span>
 					<span v-else
 						class="live-relative-timestamp"


### PR DESCRIPTION
The timestamp of scheduled announcements gets updated and updates to `invalid date`. Apparently `live-relative-timestamp`s can't work like this here in this case.

![Bildschirmfoto vom 2024-09-24 10-00-00](https://github.com/user-attachments/assets/f29806d4-a19f-4a34-9581-fd0379cc4c9c)
