### PR TITLE
fix(notification): Throw new exceptions to stop debug logs

### DIFF
--- a/lib/Activity/Provider.php
+++ b/lib/Activity/Provider.php
@@ -26,6 +26,7 @@ namespace OCA\AnnouncementCenter\Activity;
 use OCA\AnnouncementCenter\Manager;
 use OCA\AnnouncementCenter\Model\Announcement;
 use OCA\AnnouncementCenter\Model\AnnouncementDoesNotExistException;
+use OCP\Activity\Exceptions\UnknownActivityException;
 use OCP\Activity\IEvent;
 use OCP\Activity\IManager as IActivityManager;
 use OCP\Activity\IProvider;
@@ -80,6 +81,9 @@ class Provider implements IProvider {
 			$event->getSubject() !== 'announcementsubject' && // 3.1 and later
 			strpos($event->getSubject(), 'announcementsubject#') !== 0) // 3.0 and before
 		) {
+			if (class_exists(UnknownActivityException::class)) {
+				throw new UnknownActivityException('Unknown app');
+			}
 			throw new \InvalidArgumentException('Unknown subject');
 		}
 

--- a/lib/Notification/Notifier.php
+++ b/lib/Notification/Notifier.php
@@ -34,6 +34,7 @@ use OCP\Notification\AlreadyProcessedException;
 use OCP\Notification\IManager as INotificationManager;
 use OCP\Notification\INotification;
 use OCP\Notification\INotifier;
+use OCP\Notification\UnknownNotificationException;
 
 class Notifier implements INotifier {
 
@@ -93,6 +94,9 @@ class Notifier implements INotifier {
 	public function prepare(INotification $notification, string $languageCode): INotification {
 		if ($notification->getApp() !== 'announcementcenter') {
 			// Not my app => throw
+			if (class_exists(UnknownNotificationException::class)) {
+				throw new UnknownNotificationException('Unknown app');
+			}
 			throw new \InvalidArgumentException('Unknown app');
 		}
 
@@ -102,6 +106,9 @@ class Notifier implements INotifier {
 		$i = $notification->getSubject();
 		if ($i !== 'announced') {
 			// Unknown subject => Unknown notification => throw
+			if (class_exists(UnknownNotificationException::class)) {
+				throw new UnknownNotificationException('Unknown subject');
+			}
 			throw new \InvalidArgumentException('Unknown subject');
 		}
 


### PR DESCRIPTION
## Before
Debug log spam when opening the dashboard with the activity widget with Nextcloud 30+
![grafik](https://github.com/user-attachments/assets/b48ec59a-c2db-484b-9be0-83b595f06af0)

## After
No more log