### PR TITLE
fix(settings): Fix missing section name in admin settings

### DIFF
--- a/src/AdminSettings.vue
+++ b/src/AdminSettings.vue
@@ -4,7 +4,7 @@
 -->
 
 <template>
-	<NcSettingsSection :title="t('announcementcenter', 'Announcements')">
+	<NcSettingsSection :name="t('announcementcenter', 'Announcements')">
 		<NcSettingsSelectGroup id="announcementcenter_admin_group"
 			v-model="adminGroups"
 			:label="t('announcementcenter', 'These groups will be able to post announcements.')"


### PR DESCRIPTION
### Before
![grafik](https://github.com/user-attachments/assets/406abab3-adaa-4eb2-a903-aabc9d6fcc37)

### After
![grafik](https://github.com/user-attachments/assets/82ad7b7c-6f7a-405c-92af-dc32f4adb033)
