### PR TITLE
[main] Update nextcloud/ocp dependency

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -71,12 +71,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/nextcloud-deps/ocp.git",
-                "reference": "84030d9675281482ea53c73a0cf1aaaffa349dc4"
+                "reference": "c546a0eb17712f6d4e2cd64d233391076f7c2e12"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/84030d9675281482ea53c73a0cf1aaaffa349dc4",
-                "reference": "84030d9675281482ea53c73a0cf1aaaffa349dc4",
+                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/c546a0eb17712f6d4e2cd64d233391076f7c2e12",
+                "reference": "c546a0eb17712f6d4e2cd64d233391076f7c2e12",
                 "shasum": ""
             },
             "require": {
@@ -107,7 +107,7 @@
                 "issues": "https://github.com/nextcloud-deps/ocp/issues",
                 "source": "https://github.com/nextcloud-deps/ocp/tree/stable30"
             },
-            "time": "2025-02-15T00:42:52+00:00"
+            "time": "2025-02-22T00:42:33+00:00"
         },
         {
             "name": "psr/clock",


### PR DESCRIPTION
Auto-generated update of [nextcloud/ocp](https://github.com/nextcloud-deps/ocp/) dependency