### PR TITLE
[main] Update nextcloud/ocp dependency

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -71,12 +71,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/nextcloud-deps/ocp.git",
-                "reference": "234140dcda2021d01bb7196999f93ea5384519f0"
+                "reference": "f9705f567a8590b0f84a7d6dec0663b3155f2046"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/234140dcda2021d01bb7196999f93ea5384519f0",
-                "reference": "234140dcda2021d01bb7196999f93ea5384519f0",
+                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/f9705f567a8590b0f84a7d6dec0663b3155f2046",
+                "reference": "f9705f567a8590b0f84a7d6dec0663b3155f2046",
                 "shasum": ""
             },
             "require": {
@@ -107,7 +107,7 @@
                 "issues": "https://github.com/nextcloud-deps/ocp/issues",
                 "source": "https://github.com/nextcloud-deps/ocp/tree/stable30"
             },
-            "time": "2025-05-07T00:51:23+00:00"
+            "time": "2025-05-16T00:52:15+00:00"
         },
         {
             "name": "psr/clock",


### PR DESCRIPTION
Auto-generated update of [nextcloud/ocp](https://github.com/nextcloud-deps/ocp/) dependency