### PR TITLE
[main] Update nextcloud/ocp dependency

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -71,12 +71,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/nextcloud-deps/ocp.git",
-                "reference": "5d72a14f4102124f1c1e8b7dc8bf74e4ebfe587e"
+                "reference": "74e12867ecdd454145b21f90fe6cb3d96abb9666"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/5d72a14f4102124f1c1e8b7dc8bf74e4ebfe587e",
-                "reference": "5d72a14f4102124f1c1e8b7dc8bf74e4ebfe587e",
+                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/74e12867ecdd454145b21f90fe6cb3d96abb9666",
+                "reference": "74e12867ecdd454145b21f90fe6cb3d96abb9666",
                 "shasum": ""
             },
             "require": {
@@ -107,7 +107,7 @@
                 "issues": "https://github.com/nextcloud-deps/ocp/issues",
                 "source": "https://github.com/nextcloud-deps/ocp/tree/stable30"
             },
-            "time": "2025-05-24T00:49:27+00:00"
+            "time": "2025-05-28T00:52:27+00:00"
         },
         {
             "name": "psr/clock",


### PR DESCRIPTION
Auto-generated update of [nextcloud/ocp](https://github.com/nextcloud-deps/ocp/) dependency