### PR TITLE
fix: leave the NcAppSidebar rendering logic to the component

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -144,10 +144,11 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-::v-deep .comments {
-	margin: 10px;
+:deep(.comments) {
+	overflow: hidden auto;
+	height: 100%;
 }
-::v-deep .empty-content__icon span {
+:deep(.empty-content__icon span) {
 	width: 64px;
 	height: 64px;
 	background-size: 64px;

--- a/src/App.vue
+++ b/src/App.vue
@@ -26,8 +26,9 @@
 				</template>
 			</NcEmptyContent>
 		</NcAppContent>
-		<NcAppSidebar v-show="activeId !== 0 && activateAnnouncementHasComments"
+		<NcAppSidebar :open="activeId !== 0 && activateAnnouncementHasComments"
 			:name="activeAnnouncementTitle + ' - ' + t('announcementcenter', 'Comments')"
+			no-toggle
 			@close="onClickAnnouncement(0)">
 			<div ref="sidebar"
 				class="comments" />


### PR DESCRIPTION
Fix #936

<img width="488" alt="image" src="https://github.com/user-attachments/assets/989d5c2e-098e-4387-9b5b-c8d80ae65b7e" />
<img width="532" alt="image" src="https://github.com/user-attachments/assets/980a1739-152b-4957-8fee-3d88656c6b51" />
<img width="532" alt="image" src="https://github.com/user-attachments/assets/450f5ffa-ee83-4836-905d-d27783c4ccd1" />
