### PR TITLE
fix(design): Move to outline icons

### DIFF
--- a/src/Components/Announcement.vue
+++ b/src/Components/Announcement.vue
@@ -41,13 +41,20 @@
 					:force-menu="true"
 					:boundaries-element="boundariesElement">
 					<NcActionButton v-if="notifications"
-						icon="icon-notifications-off"
 						:close-after-click="true"
 						:name="t('announcementcenter', 'Clear notifications')"
-						@click="onRemoveNotifications" />
-					<NcActionButton icon="icon-delete"
-						:name="t('announcementcenter', 'Delete announcement')"
-						@click="onDeleteAnnouncement" />
+						@click="onRemoveNotifications">
+						<template #icon>
+							<IconBellOffOutline size="20" />
+						</template>
+					</NcActionButton>
+					<NcActionButton :name="t('announcementcenter', 'Delete announcement')"
+						class="critical"
+						@click="onDeleteAnnouncement">
+						<template #icon>
+							<IconTrashCanOutline size="20" />
+						</template>
+					</NcActionButton>
 				</NcActions>
 			</div>
 		</div>
@@ -89,10 +96,14 @@ import {
 	deleteAnnouncement,
 	removeNotifications,
 } from '../services/announcementsService.js'
+import IconBellOffOutline from 'vue-material-design-icons/BellOffOutline.vue'
+import IconTrashCanOutline from 'vue-material-design-icons/TrashCanOutline.vue'
 
 export default {
 	name: 'Announcement',
 	components: {
+		IconBellOffOutline,
+		IconTrashCanOutline,
 		NcActions,
 		NcActionButton,
 		NcAvatar,
@@ -322,5 +333,9 @@ export default {
 		&__comments {
 			margin-left: -16px;
 		}
+	}
+
+	.critical > :deep(.action-button) {
+		color: var(--color-text-error);
 	}
 </style>

--- a/src/Components/NewForm.vue
+++ b/src/Components/NewForm.vue
@@ -66,7 +66,7 @@
 					:min="new Date()"
 					@change="setScheduleTime">
 					<template #icon>
-						<ClockStart :size="20" />
+						<IconClockStart :size="20" />
 					</template>
 				</NcActionInput>
 				<NcActionSeparator />
@@ -80,7 +80,7 @@
 					id-native-date-time-picker="date-time-picker-delete_id"
 					@change="setDeleteTime">
 					<template #icon>
-						<ClockEnd :size="20" />
+						<IconClockEnd :size="20" />
 					</template>
 				</NcActionInput>
 			</NcActions>
@@ -103,15 +103,15 @@ import {
 import { showError } from '@nextcloud/dialogs'
 import { remark } from 'remark'
 import strip from 'strip-markdown'
-import ClockStart from 'vue-material-design-icons/ClockStart.vue'
-import ClockEnd from 'vue-material-design-icons/ClockEnd.vue'
+import IconClockStart from 'vue-material-design-icons/ClockStart.vue'
+import IconClockEnd from 'vue-material-design-icons/ClockEnd.vue'
 
 export default {
 	name: 'NewForm',
 
 	components: {
-		ClockEnd,
-		ClockStart,
+		IconClockEnd,
+		IconClockStart,
 		NcActions,
 		NcActionCheckbox,
 		NcActionInput,


### PR DESCRIPTION
Before | After
---|---
<img width="366" height="225" alt="Bildschirmfoto vom 2025-08-29 11-17-01" src="https://github.com/user-attachments/assets/03c6a122-b3ef-4efb-b353-a1d3d56d7eaa" /> | <img width="336" height="187" alt="Bildschirmfoto vom 2025-08-29 11-16-05" src="https://github.com/user-attachments/assets/7f17ee01-f1cf-4ec8-ade7-d36f16173b96" />
