### PR TITLE
fix: announcement header fixes

### DIFF
--- a/src/Components/Announcement.vue
+++ b/src/Components/Announcement.vue
@@ -28,12 +28,11 @@
 					<template v-if="isAdmin">
 						·
 						<template v-if="isVisibleToEveryone">
-							{{ visibilityLabel }}
+							<span v-html="visibilityLabel"></span>
 						</template>
 						<span v-else
-							:title="visibilityTitle">
-							{{ visibilityLabel }}
-						</span>
+							:title="visibilityTitle"
+							v-html="visibilityLabel"></span>
 					</template>
 				</div>
 
@@ -285,6 +284,7 @@ export default {
 					flex: 1 1 auto;
 					display: flex;
 					align-items: center;
+					flex-wrap: wrap;
 
 					:deep(.avatardiv) {
 						margin-right: 4px;

--- a/src/Components/Announcement.vue
+++ b/src/Components/Announcement.vue
@@ -26,13 +26,13 @@
 						:timestamp="time * 1000" />
 
 					<template v-if="isAdmin">
-						·
-						<template v-if="isVisibleToEveryone">
-							<span v-html="visibilityLabel"></span>
+						 · 
+						 <template v-if="isVisibleToEveryone">
+							{{ safeVisibilityLabel  }}
 						</template>
-						<span v-else
-							:title="visibilityTitle"
-							v-html="visibilityLabel"></span>
+						<span v-else :title="visibilityTitle">
+							{{ safeVisibilityLabel  }}
+						</span>
 					</template>
 				</div>
 
@@ -178,6 +178,12 @@ export default {
 				|| this.groups.filter(({ id }) => {
 					return id === 'everyone'
 				}).length === 1
+		},
+
+		safeVisibilityLabel() {
+			const txt = document.createElement('textarea')
+			txt.innerHTML = this.visibilityLabel
+			return txt.value
 		},
 
 		visibilityLabel() {


### PR DESCRIPTION
Add flex-wrap to .announcement__header__details__info for proper line wrapping of author and visibility info.
Fix group names with ampersand (&) in visibility label by using v-html to render the character correctly.

Fixes #974