### PR TITLE
[main] ci(actions): Update workflow templates from organization template repository

### DIFF
--- a/.github/actions-lock.txt
+++ b/.github/actions-lock.txt
@@ -1,6 +1,6 @@
 # SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
 # SPDX-License-Identifier: MIT
-f776ffe8120cb9a8b2579bc30a7f7ca7 appstore-build-publish.yml
+3b7702f2bde1241a89c5968d425da533 appstore-build-publish.yml
 7dd8d21d9dd013196cd4bdbf7c24db6f dependabot-approve-merge.yml
 54f293d9abe11ac0035a7bbb96a4e453 lint-eslint.yml
 80a58e5584612def0e751fcfb7669814 lint-info-xml.yml
@@ -12,8 +12,8 @@ c965845a0def7b39d872e47e93dd1139 node.yml
 ec7d1084fbb3a6803dbabf3acdd17ac8 phpunit-oci.yml
 29b359a5b76e7ff8cd85af34b3bf36e3 phpunit-pgsql.yml
 182cc739d33a2441d3a9278a9bff55b4 phpunit-sqlite.yml
-d21beb0d6966d46b2b6b6e868e863a7d psalm-matrix.yml
+bb8575fb596bde0afa9604bdcc48612e psalm-matrix.yml
 7db5b820f3750eebe988005a0bb2febd reuse.yml
-a064cb13abb8fa131c50af7f826f0331 sync-workflow-templates.yml
+a4ad57688740c06ff327edaba69b2755 sync-workflow-templates.yml
 800d5b188aa885626cf4169fa2dfea9e update-nextcloud-ocp-approve-merge.yml
-4a11ae5151e551424b5135496a3be600 update-nextcloud-ocp-matrix.yml
+fa22acae30b086f8d7be4daf3657b7fc update-nextcloud-ocp-matrix.yml

--- a/.github/workflows/appstore-build-publish.yml
+++ b/.github/workflows/appstore-build-publish.yml
@@ -172,7 +172,7 @@ jobs:
           tar -xvf ${{ env.APP_NAME }}.tar.gz
           cd ../../../
           # Setting up keys
-          echo '${{ secrets.APP_PRIVATE_KEY }}' > ${{ env.APP_NAME }}.key # zizmor: ignore[secrets-outside-env]
+          echo '${{ secrets.APP_PRIVATE_KEY }}' > ${{ env.APP_NAME }}.key
           wget --quiet "https://github.com/nextcloud/app-certificate-requests/raw/master/${{ env.APP_NAME }}/${{ env.APP_NAME }}.crt"
           # Signing
           php nextcloud/occ integrity:sign-app --privateKey=../${{ env.APP_NAME }}.key --certificate=../${{ env.APP_NAME }}.crt --path=../${{ env.APP_NAME }}/build/artifacts/${{ env.APP_NAME }}
@@ -194,6 +194,6 @@ jobs:
         uses: nextcloud-releases/nextcloud-appstore-push-action@a011fe619bcf6e77ddebc96f9908e1af4071b9c1 # v1.0.3
         with:
           app_name: ${{ env.APP_NAME }}
-          appstore_token: ${{ secrets.APPSTORE_TOKEN }} # zizmor: ignore[secrets-outside-env]
+          appstore_token: ${{ secrets.APPSTORE_TOKEN }}
           download_url: ${{ steps.attach_to_release.outputs.browser_download_url }}
-          app_private_key: ${{ secrets.APP_PRIVATE_KEY }} # zizmor: ignore[secrets-outside-env]
+          app_private_key: ${{ secrets.APP_PRIVATE_KEY }}

--- a/.github/workflows/psalm-matrix.yml
+++ b/.github/workflows/psalm-matrix.yml
@@ -67,9 +67,6 @@ jobs:
           composer remove nextcloud/ocp --dev --no-scripts
           composer i
 
-      - name: Check for vulnerable PHP dependencies
-        run: composer require --dev roave/security-advisories:dev-latest
-
       - name: Install dependencies # zizmor: ignore[template-injection]
         run: composer require --dev 'nextcloud/ocp:${{ matrix.ocp-version }}' --ignore-platform-reqs --with-dependencies
 

--- a/.github/workflows/sync-workflow-templates.yml
+++ b/.github/workflows/sync-workflow-templates.yml
@@ -120,7 +120,7 @@ jobs:
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
-          token: ${{ secrets.COMMAND_BOT_WORKFLOWS }} # zizmor: ignore[secrets-outside-env]
+          token: ${{ secrets.COMMAND_BOT_WORKFLOWS }}
           commit-message: 'ci(actions): Update workflow templates from organization template repository'
           committer: GitHub <noreply@github.com>
           author: nextcloud-command <nextcloud-command@users.noreply.github.com>

--- a/.github/workflows/update-nextcloud-ocp-matrix.yml
+++ b/.github/workflows/update-nextcloud-ocp-matrix.yml
@@ -90,7 +90,7 @@ jobs:
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
-          token: ${{ secrets.COMMAND_BOT_PAT }} # zizmor: ignore[secrets-outside-env]
+          token: ${{ secrets.COMMAND_BOT_PAT }}
           commit-message: 'chore(dev-deps): Bump nextcloud/ocp package'
           committer: GitHub <noreply@github.com>
           author: nextcloud-command <nextcloud-command@users.noreply.github.com>


### PR DESCRIPTION
Automated update of all workflow templates from [nextcloud/.github](https://github.com/nextcloud/.github)
- 🆙 Updated [appstore-build-publish.yml](https://github.com/nextcloud/.github/commits/master/workflow-templates/appstore-build-publish.yml)
- 🆙 Updated [psalm-matrix.yml](https://github.com/nextcloud/.github/commits/master/workflow-templates/psalm-matrix.yml)
- 🆙 Updated [sync-workflow-templates.yml](https://github.com/nextcloud/.github/commits/master/workflow-templates/sync-workflow-templates.yml)
  - Patch applied
- 🆙 Updated [update-nextcloud-ocp-matrix.yml](https://github.com/nextcloud/.github/commits/master/workflow-templates/update-nextcloud-ocp-matrix.yml)