### PR TITLE
Adapt to NC34+ comments

### DIFF
--- a/lib/Controller/PageController.php
+++ b/lib/Controller/PageController.php
@@ -18,6 +18,7 @@ use OCP\AppFramework\Services\IAppConfig;
 use OCP\AppFramework\Services\IInitialState;
 use OCP\Comments\ICommentsManager;
 use OCP\IRequest;
+use OCP\ServerVersion;
 use OCP\Util;
 
 class PageController extends Controller {
@@ -28,6 +29,7 @@ class PageController extends Controller {
 		protected ICommentsManager $commentsManager,
 		protected IInitialState $initialState,
 		protected IAppConfig $appConfig,
+		private ServerVersion $serverVersion,
 	) {
 		parent::__construct($appName, $request);
 	}
@@ -65,6 +67,9 @@ class PageController extends Controller {
 		);
 
 		$this->commentsManager->load();
+		if ($this->serverVersion->getMajorVersion() >= 34) {
+			Util::addStyle('comments', 'comments-app');
+		}
 		Util::addScript('announcementcenter', 'announcementcenter-main', 'comments');
 
 		return new TemplateResponse(Application::APP_ID, 'main', [

--- a/src/App.vue
+++ b/src/App.vue
@@ -144,10 +144,10 @@ export default {
 						},
 					},
 				)
+				this.commentsView.$mount(this.$refs.sidebar)
 			}
 
 			await this.commentsView.update(id)
-			this.commentsView.$mount(this.$refs.sidebar)
 		},
 	},
 }

--- a/tests/Controller/PageControllerTest.php
+++ b/tests/Controller/PageControllerTest.php
@@ -15,6 +15,8 @@ use OCP\AppFramework\Services\IAppConfig;
 use OCP\AppFramework\Services\IInitialState;
 use OCP\Comments\ICommentsManager;
 use OCP\IRequest;
+use OCP\Server;
+use OCP\ServerVersion;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\MockObject\MockObject;
 
@@ -27,6 +29,7 @@ class PageControllerTest extends TestCase {
 	protected ICommentsManager&MockObject $commentsManager;
 	protected IInitialState&MockObject $initialState;
 	protected IAppConfig&MockObject $appConfig;
+	protected ServerVersion $serverVersion;
 
 	protected function setUp(): void {
 		parent::setUp();
@@ -36,6 +39,7 @@ class PageControllerTest extends TestCase {
 		$this->commentsManager = $this->createMock(ICommentsManager::class);
 		$this->initialState = $this->createMock(IInitialState::class);
 		$this->appConfig = $this->createMock(IAppConfig::class);
+		$this->serverVersion = Server::get(ServerVersion::class);
 	}
 
 	protected function getController(): PageController {
@@ -46,6 +50,7 @@ class PageControllerTest extends TestCase {
 			$this->commentsManager,
 			$this->initialState,
 			$this->appConfig,
+			$this->serverVersion,
 		);
 	}
 


### PR DESCRIPTION
The comments style is missing since https://github.com/nextcloud/server/pull/58353 on NC34.

<img width="493" height="297" alt="image" src="https://github.com/user-attachments/assets/9a88707b-686f-4cff-a434-1624a084ffb3" />

Also, mounting the commentsView each time breaks the sidebar when switching announcement, which is fixed in the second commit.