### PR TITLE
fix:show mention in comments before sending

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -129,6 +129,9 @@ export default {
 			}
 
 			if (id === 0) {
+				if (this.commentsView) {
+					this.commentsView.$unmount()
+				}
 				// Destroy the comments view as the sidebar is destroyed
 				this.commentsView = null
 				return


### PR DESCRIPTION

Fixes #897 - @mention autocomplete not working in announcement comments

When the sidebar closes, `this.commentsView = null` was set without calling `$unmount()`, leaving the old Vue app mounted on the DOM. The next open mounted a new instance on the same element, but TributeJS had already attached to the old (stale) contenteditable  so the new editor had no mention autocomplete.

Fix: Call `commentsView.$unmount()` before nulling the reference, so the Vue app is fully torn down (including TributeJS detachment) before the next open creates a fresh instance.