### PR TITLE
Use SPDX license identifier

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -22,7 +22,7 @@
 
 🔔 Notifications integration]]></description>
 	<version>7.5.0-dev.0</version>
-	<licence>agpl</licence>
+	<licence>AGPL-3.0-or-later</licence>
 	<author>Joas Schilling</author>
 	<namespace>AnnouncementCenter</namespace>
 

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
 	"name": "nextcloud/announcementcenter",
 	"type": "project",
-	"license": "AGPL",
+	"license": "AGPL-3.0-or-later",
 	"authors": [
 		{
 			"name": "Joas Schilling",


### PR DESCRIPTION
unifying the license string, already used in package.json and supported in info.xml since 31, so no issue given min-version is set to 32 at the moment.

## 🤖 AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
