### PR TITLE
fix(ux): Bring back "Schedule announcement time" label

### DIFF
--- a/src/Components/NewForm.vue
+++ b/src/Components/NewForm.vue
@@ -62,7 +62,6 @@
 					:label="t('announcementcenter', 'Schedule announcement time')"
 					:disabled="!scheduleEnabled"
 					isNativePicker
-					hideLabel
 					:modelValue="scheduleTime"
 					:min="new Date()"
 					@update:modelValue="setScheduleTime">
@@ -76,7 +75,6 @@
 					:label="t('announcementcenter', 'Schedule deletion time')"
 					:disabled="!deleteEnabled"
 					isNativePicker
-					hideLabel
 					:modelValue="deleteTime"
 					:min="getMinDeleteTime()"
 					idNativeDateTimePicker="date-time-picker-delete_id"


### PR DESCRIPTION
The "Schedule announcement time" label has disappeared, and in my opinion, this negatively impacts the user experience. I want to bring it back. 

⚠️ Warning : 

- Not tested (no test environment)
- I don't know if this little change is enough

| Currently | Expected result (pure simulation) | 
| --- | --- |
| <img width="364" height="459" alt="2026-08-04_11-41_1" src="https://github.com/user-attachments/assets/ad6eb441-2414-44d1-afaa-f1af07f79056" /> | <img width="364" height="459" alt="2026-08-04_11-41" src="https://github.com/user-attachments/assets/0dbc7830-4980-44f8-961b-bd9cad8f7c6b" /> |