### PR TITLE
feat: dispatching AnnouncementPublished event

### DIFF
--- a/lib/Events/AnnouncementPublished.php
+++ b/lib/Events/AnnouncementPublished.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\AnnouncementCenter\Events;
+
+use OCA\AnnouncementCenter\Model\Announcement;
+use OCP\EventDispatcher\Event;
+use OCP\EventDispatcher\IWebhookCompatibleEvent;
+
+class AnnouncementPublished extends Event implements IWebhookCompatibleEvent {
+	public function __construct(
+		private Announcement $announcement,
+	) {
+		parent::__construct();
+	}
+
+	#[\Override]
+	public function getWebhookSerializable(): array {
+		return [
+			'subject' => $this->announcement->getSubject(),
+			'message' => $this->announcement->getMessage(),
+			'plainMessage' => $this->announcement->getPlainMessage(),
+			'scheduleTime' => $this->announcement->getScheduleTime(),
+			'deleteTime' => $this->announcement->getDeleteTime(),
+		];
+	}
+}

--- a/lib/Manager.php
+++ b/lib/Manager.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace OCA\AnnouncementCenter;
 
+use OCA\AnnouncementCenter\Events\AnnouncementPublished;
 use OCA\AnnouncementCenter\Model\Announcement;
 use OCA\AnnouncementCenter\Model\AnnouncementDoesNotExistException;
 use OCA\AnnouncementCenter\Model\AnnouncementMapper;
@@ -20,6 +21,7 @@ use OCP\AppFramework\Services\IAppConfig;
 use OCP\BackgroundJob\IJobList;
 use OCP\Comments\ICommentsManager;
 use OCP\DB\Exception;
+use OCP\EventDispatcher\IEventDispatcher;
 use OCP\IGroupManager;
 use OCP\IUser;
 use OCP\IUserSession;
@@ -35,6 +37,7 @@ class Manager {
 		protected IJobList $jobList,
 		protected IUserSession $userSession,
 		protected NotificationType $notificationType,
+		protected IEventDispatcher $eventDispatcher,
 		protected IAppConfig $appConfig,
 	) {
 	}
@@ -104,6 +107,8 @@ class Manager {
 				'emails' => $this->notificationType->getEmail($notificationOptions),
 			]);
 		}
+
+		$this->eventDispatcher->dispatchTyped(new AnnouncementPublished($announcement));
 	}
 
 	protected function addGroupLink(Announcement $announcement, string $gid): void {

--- a/tests/ManagerTest.php
+++ b/tests/ManagerTest.php
@@ -19,6 +19,7 @@ use OCP\AppFramework\Db\DoesNotExistException;
 use OCP\AppFramework\Services\IAppConfig;
 use OCP\BackgroundJob\IJobList;
 use OCP\Comments\ICommentsManager;
+use OCP\EventDispatcher\IEventDispatcher;
 use OCP\IDBConnection;
 use OCP\IGroupManager;
 use OCP\IUser;
@@ -38,6 +39,7 @@ class ManagerTest extends TestCase {
 	protected IJobList&MockObject $jobList;
 	protected IUserSession&MockObject $userSession;
 	protected NotificationType&MockObject $notificationType;
+	protected IEventDispatcher&MockObject $eventDispatcher;
 	protected IAppConfig&MockObject $appConfig;
 	protected Manager $manager;
 
@@ -52,6 +54,7 @@ class ManagerTest extends TestCase {
 		$this->jobList = $this->createMock(IJobList::class);
 		$this->userSession = $this->createMock(IUserSession::class);
 		$this->notificationType = $this->createMock(NotificationType::class);
+		$this->eventDispatcher = $this->createMock(IEventDispatcher::class);
 		$this->appConfig = $this->createMock(IAppConfig::class);
 
 		$this->manager = new Manager(
@@ -63,12 +66,23 @@ class ManagerTest extends TestCase {
 			$this->jobList,
 			$this->userSession,
 			$this->notificationType,
+			$this->eventDispatcher,
 			$this->appConfig,
 		);
 
 		$query = \OCP\Server::get(IDBConnection::class)->getQueryBuilder();
 		$query->delete('announcements')->executeStatement();
 		$query->delete('announcements_map')->executeStatement();
+	}
+
+	public function testAnnounceGood(): void {
+		$this->groupManager->expects(self::never())
+			->method('groupExists');
+
+		$this->eventDispatcher->expects(self::once())
+			->method('dispatchTyped');
+
+		$this->manager->announce('foo', 'bar', 'baz', 'admin', 0, [], false, 0);
 	}
 
 	public function testGetAnnouncementNotExist(): void {


### PR DESCRIPTION
Added an Event to notify other apps (both local than remote, using webhooks) about announcement publishing.

Ref #1050 (as the event can be listened by the `mohamedsakhri/nextcloud-announcementbanner` app and display the attached announcement as preferred).