### PR TITLE
fix: infinite scroll of announcements

### DIFF
--- a/lib/Controller/APIController.php
+++ b/lib/Controller/APIController.php
@@ -44,8 +44,8 @@ class APIController extends OCSController {
 	}
 
 	#[NoAdminRequired]
-	public function get(int $offset = 0): DataResponse {
-		$announcements = $this->manager->getAnnouncements($offset);
+	public function get(int $offset = 0, int $limit = 7): DataResponse {
+		$announcements = $this->manager->getAnnouncements($offset, $limit);
 		$data = array_map($this->renderAnnouncement(...), $announcements);
 		return new DataResponse($data);
 	}

--- a/src/App.vue
+++ b/src/App.vue
@@ -5,22 +5,38 @@
 
 <template>
 	<NcContent appName="announcementcenter">
-		<NcAppContent>
+		<NcAppContent
+			v-infinite-scroll="loadAnnouncements"
+			:infiniteScrollImmediateCheck="false"
+			:infiniteScrollDisabled="false"
+			:infiniteScrollDistance="300">
 			<NewForm v-if="isAdmin" />
 
-			<transition-group name="fade-collapse" tag="div">
-				<Announcement
-					v-for="announcement in announcements"
-					:key="announcement.id"
-					:isAdmin="isAdmin"
-					:authorId="announcement.author_id"
-					:scheduleTime="announcement.schedule_time"
-					v-bind="announcement"
-					@click="onClickAnnouncement" />
-			</transition-group>
+			<div v-if="announcements.length">
+				<transition-group name="fade-collapse" tag="div">
+					<Announcement
+						v-for="announcement in announcements"
+						:key="announcement.id"
+						:isAdmin="isAdmin"
+						:authorId="announcement.author_id"
+						:scheduleTime="announcement.schedule_time"
+						v-bind="announcement"
+						@click="onClickAnnouncement" />
+				</transition-group>
+
+				<div class="load-more">
+					<NcButton
+						v-if="hasMore"
+						:disabled="loading"
+						variant="secondary"
+						@click.prevent="loadAnnouncements">
+						{{ t('announcementcenter', 'Load more') }}
+					</NcButton>
+				</div>
+			</div>
 
 			<NcEmptyContent
-				v-if="!announcements.length"
+				v-else
 				:name="t('announcementcenter', 'No announcements')"
 				:description="t('announcementcenter', 'There are currently no announcements …')">
 				<template #icon>
@@ -43,21 +59,24 @@
 <script>
 import { loadState } from '@nextcloud/initial-state'
 import { t } from '@nextcloud/l10n'
-import NcAppContent from '@nextcloud/vue/components/NcAppContent'
-import NcAppSidebar from '@nextcloud/vue/components/NcAppSidebar'
-import NcContent from '@nextcloud/vue/components/NcContent'
-import NcEmptyContent from '@nextcloud/vue/components/NcEmptyContent'
+import { NcAppContent, NcAppSidebar, NcButton, NcContent, NcEmptyContent } from '@nextcloud/vue'
 import Announcement from './Components/Announcement.vue'
 import NewForm from './Components/NewForm.vue'
+import infiniteScroll from './directives/infinite-scroll.js'
 import { getAnnouncements } from './services/announcementsService.js'
 
 export default {
 	name: 'App',
 
+	directives: {
+		infiniteScroll,
+	},
+
 	components: {
 		Announcement,
 		NcAppContent,
 		NcAppSidebar,
+		NcButton,
 		NcContent,
 		NcEmptyContent,
 		NewForm,
@@ -68,6 +87,8 @@ export default {
 			isAdmin: loadState('announcementcenter', 'isAdmin'),
 			commentsView: null,
 			activeId: 0,
+			hasMore: true,
+			loading: false,
 		}
 	},
 
@@ -77,6 +98,14 @@ export default {
 			return announcements.sort((a1, a2) => {
 				return a2.time - a1.time
 			})
+		},
+
+		loadOffset() {
+			if (this.announcements.length === 0) {
+				return 0
+			} else {
+				return this.announcements.at(-1).id
+			}
 		},
 
 		activeAnnouncement() {
@@ -108,12 +137,24 @@ export default {
 		t,
 
 		async loadAnnouncements() {
-			const response = await getAnnouncements()
+			if (this.hasMore === false) {
+				return
+			}
+
+			this.loading = true
+
+			const response = await getAnnouncements(this.loadOffset, 7)
 			const announcements = response.data?.ocs?.data || []
+
+			if (announcements.length < 7) {
+				this.hasMore = false
+			}
 
 			announcements.forEach((announcement) => {
 				this.$store.dispatch('addAnnouncement', announcement)
 			})
+
+			this.loading = false
 		},
 
 		/**
@@ -187,5 +228,11 @@ export default {
 .fade-enter,
 .fade-leave-to {
 	opacity: 0;
+}
+
+.load-more {
+	margin: 0 auto 3em auto;
+	display: flex;
+    justify-content: center;
 }
 </style>

--- a/src/directives/infinite-scroll.js
+++ b/src/directives/infinite-scroll.js
@@ -1,0 +1,221 @@
+/**
+ * SPDX-FileCopyrightText: 2021-2024 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-FileCopyrightText: 2015-2017 vue-infinite-scroll authors
+ * SPDX-License-Identifier: MIT
+ *
+ * Vendored and fixed version of the abandoned https://github.com/ElemeFE/vue-infinite-scroll lib
+ * Refactored for Vue 2.7 / Vue 3 dual compatibility.
+ */
+
+import { nextTick } from 'vue'
+
+const ctx = '@@InfiniteScroll'
+
+function throttle(fn, delay) {
+	let now, lastExec, timer, context, args
+
+	const execute = function() {
+		fn.apply(context, args)
+		lastExec = now
+	}
+
+	return function() {
+		context = this
+		args = arguments
+
+		now = Date.now()
+
+		if (timer) {
+			clearTimeout(timer)
+			timer = null
+		}
+
+		if (lastExec) {
+			const diff = delay - (now - lastExec)
+			if (diff < 0) {
+				execute()
+			} else {
+				timer = setTimeout(() => {
+					execute()
+				}, diff)
+			}
+		} else {
+			execute()
+		}
+	}
+}
+
+function getScrollTop(element) {
+	if (element === window) {
+		return Math.max(window.pageYOffset || 0, document.documentElement.scrollTop)
+	}
+
+	return element.scrollTop
+}
+
+const getComputedStyle = document.defaultView.getComputedStyle
+
+function getScrollEventTarget(element) {
+	let currentNode = element
+	while (currentNode && currentNode.tagName !== 'HTML' && currentNode.tagName !== 'BODY' && currentNode.nodeType === 1) {
+		const overflowY = getComputedStyle(currentNode).overflowY
+		if (overflowY === 'scroll' || overflowY === 'auto') {
+			return currentNode
+		}
+		currentNode = currentNode.parentNode
+	}
+	return window
+}
+
+function getVisibleHeight(element) {
+	if (element === window) {
+		return document.documentElement.clientHeight
+	}
+
+	return element.clientHeight
+}
+
+function getElementTop(element) {
+	if (element === window) {
+		return getScrollTop(window)
+	}
+	return element.getBoundingClientRect().top + getScrollTop(window)
+}
+
+function isAttached(element) {
+	let currentNode = element.parentNode
+	while (currentNode) {
+		if (currentNode.tagName === 'HTML') {
+			return true
+		}
+		if (currentNode.nodeType === 11) {
+			return false
+		}
+		currentNode = currentNode.parentNode
+	}
+	return false
+}
+
+function doBind() {
+	if (this.binded) {
+		return
+	}
+	this.binded = true
+
+	const directive = this
+	const element = directive.el
+
+	const throttleDelayExpr = element.getAttribute('infinite-scroll-throttle-delay')
+	let throttleDelay = 200
+	if (throttleDelayExpr) {
+		throttleDelay = Number(directive.vm[throttleDelayExpr] || throttleDelayExpr)
+		if (isNaN(throttleDelay) || throttleDelay < 0) {
+			throttleDelay = 200
+		}
+	}
+	directive.throttleDelay = throttleDelay
+
+	directive.scrollEventTarget = getScrollEventTarget(element)
+	directive.scrollListener = throttle(doCheck.bind(directive), directive.throttleDelay)
+	directive.scrollEventTarget.addEventListener('scroll', directive.scrollListener)
+
+	const disabledExpr = element.getAttribute('infinite-scroll-disabled')
+	let disabled = false
+
+	if (disabledExpr) {
+		disabled = Boolean(directive.vm[disabledExpr])
+	}
+	directive.disabled = disabled
+
+	const distanceExpr = element.getAttribute('infinite-scroll-distance')
+	let distance = 0
+	if (distanceExpr) {
+		distance = Number(directive.vm[distanceExpr] || distanceExpr)
+		if (isNaN(distance)) {
+			distance = 0
+		}
+	}
+	directive.distance = distance
+
+	const immediateCheckExpr = element.getAttribute('infinite-scroll-immediate-check')
+	let immediateCheck = true
+	if (immediateCheckExpr) {
+		immediateCheck = Boolean(directive.vm[immediateCheckExpr])
+	}
+	directive.immediateCheck = immediateCheck
+
+	if (immediateCheck) {
+		doCheck.call(directive)
+	}
+}
+
+function doCheck(force) {
+	const scrollEventTarget = this.scrollEventTarget
+	const element = this.el
+	const distance = this.distance
+
+	if (force !== true && this.disabled) {
+		return
+	}
+	const viewportScrollTop = getScrollTop(scrollEventTarget)
+	const viewportBottom = viewportScrollTop + getVisibleHeight(scrollEventTarget)
+
+	let shouldTrigger
+
+	if (scrollEventTarget === element) {
+		shouldTrigger = scrollEventTarget.scrollHeight - viewportBottom <= distance
+	} else {
+		const elementBottom = getElementTop(element) - getElementTop(scrollEventTarget) + element.offsetHeight + viewportScrollTop
+
+		shouldTrigger = viewportBottom + distance >= elementBottom
+	}
+
+	if (shouldTrigger && this.expression) {
+		this.expression()
+	}
+}
+
+function onBind(el, binding, vnode) {
+	el[ctx] = {
+		el,
+		vm: binding.instance ?? vnode.context,
+		expression: binding.value,
+	}
+
+	nextTick(function() {
+		if (isAttached(el)) {
+			doBind.call(el[ctx])
+		}
+
+		el[ctx].bindTryCount = 0
+
+		const tryBind = function() {
+			if (el[ctx].bindTryCount > 10) {
+				return
+			}
+			el[ctx].bindTryCount++
+			if (isAttached(el)) {
+				doBind.call(el[ctx])
+			} else {
+				setTimeout(tryBind, 50)
+			}
+		}
+
+		tryBind()
+	})
+}
+
+function onUnbind(el) {
+	if (el && el[ctx] && el[ctx].scrollEventTarget) {
+		el[ctx].scrollEventTarget.removeEventListener('scroll', el[ctx].scrollListener)
+	}
+}
+
+export default {
+	// Vue 2
+	bind: onBind,
+	unbind: onUnbind,
+	// Vue 3
+	mounted: onBind,
+	unmounted: onUnbind,
+}

--- a/src/services/announcementsService.js
+++ b/src/services/announcementsService.js
@@ -12,10 +12,11 @@ import { generateOcsUrl } from '@nextcloud/router'
  * @param {number} [offset] The last announcement id loaded
  * @return {object} The axios response
  */
-async function getAnnouncements(offset) {
+async function getAnnouncements(offset, limit) {
 	return axios.get(generateOcsUrl('apps/announcementcenter/api/v1/announcements'), {
 		params: {
 			offset: offset || 0,
+			limit: limit || 7,
 		},
 	})
 }


### PR DESCRIPTION
Handling infinite scrolling of announcements' list.

The `infinite-scroll.js` directive has been inherited [from Mail](https://github.com/nextcloud/mail/blob/main/src/directives/infinite-scroll.js), and is one of the many methods adopted by different Nextcloud apps to handle this common interaction mechanism. Other methods would usually imply add a JS dependency.

Fixes #443 
